### PR TITLE
Update to prevent warnings while testing and update to password function

### DIFF
--- a/pjuu/auth/backend.py
+++ b/pjuu/auth/backend.py
@@ -94,7 +94,9 @@ def create_account(username, email, password):
                 '_id': uid,
                 'username': username.lower(),
                 'email': email.lower(),
-                'password': generate_password(password),
+                'password': generate_password(password,
+                                              method='pbkdf2:sha256',
+                                              salt_length=20),
                 'created': timestamp(),
                 'last_login': -1,
                 'active': False,
@@ -268,7 +270,9 @@ def change_password(user_id, password):
 
     """
     # Create the password hash from the plain-text password
-    password = generate_password(password)
+    password = generate_password(password,
+                                 method='pbkdf2:sha256:2000',
+                                 salt_length=20)
 
     return m.db.users.update({'_id': user_id},
                              {'$set': {'password': password}})

--- a/run_server.py
+++ b/run_server.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     debug_app = DebuggedApplication(app, True)
     cherrypy.tree.graft(debug_app, '/')
     cherrypy.config.update({
-        'engine.autoreload_on': True,
+        'engine.autoreload.on': True,
         'server.socket_port': 5000,
         'server.socket_host': '0.0.0.0'
     })


### PR DESCRIPTION
apparently "engine.autoreload_on" has become depreciated and replaced with "engine.autoreload.on".
changed it because it was setting my CDO off when I was testing before.
