### PR TITLE
Strong passwords for new users

### DIFF
--- a/pjuu/auth/backend.py
+++ b/pjuu/auth/backend.py
@@ -95,7 +95,7 @@ def create_account(username, email, password):
                 'username': username.lower(),
                 'email': email.lower(),
                 'password': generate_password(password,
-                                              method='pbkdf2:sha256',
+                                              method='pbkdf2:sha256:2000',
                                               salt_length=20),
                 'created': timestamp(),
                 'last_login': -1,


### PR DESCRIPTION
Spotted this while testing the docker image

New users weren't getting the same number of rounds as an existing user changing their password.
This commit changes this behaviour so that passwords are stronger for new and existing users.