### PR TITLE
Moved follow, unfolow, voting and deleting to POST.

### DIFF
--- a/pjuu/__init__.py
+++ b/pjuu/__init__.py
@@ -14,6 +14,7 @@ from flask import Flask
 from flask_mail import Mail
 from flask_pymongo import PyMongo
 from flask_redis import Redis
+from flask_wtf import CsrfProtect
 from raven.contrib.flask import Sentry
 # Pjuu imports
 from pjuu.lib.sessions import RedisSessionInterface
@@ -32,6 +33,10 @@ mongo = PyMongo()
 # redis_sessions is only used by Flask for sessions
 redis = Redis()
 redis_sessions = Redis()
+
+# Cross Site Request Forgery protection
+csrf = CsrfProtect()
+
 # Raven global Sentry object for Flask
 sentry = Sentry()
 
@@ -84,6 +89,9 @@ def create_app(config_filename='settings.py', config_dict=None):
 
     # Create the Redis session interface
     redis_sessions.init_app(app, 'SESSION_REDIS')
+
+    # Initialize CSRF protection
+    csrf.init_app(app)
 
     # Set session handler to Redis
     app.session_interface = RedisSessionInterface(redis=redis_sessions)

--- a/pjuu/posts/views.py
+++ b/pjuu/posts/views.py
@@ -199,8 +199,8 @@ def get_upload(filename):
     return be_get_upload(filename)
 
 
-@posts_bp.route('/<username>/<post_id>/upvote', methods=['GET'])
-@posts_bp.route('/<username>/<post_id>/<reply_id>/upvote', methods=['GET'])
+@posts_bp.route('/<username>/<post_id>/upvote', methods=['POST'])
+@posts_bp.route('/<username>/<post_id>/<reply_id>/upvote', methods=['POST'])
 @login_required
 def upvote(username, post_id, reply_id=None):
     """Upvotes a post.
@@ -229,8 +229,8 @@ def upvote(username, post_id, reply_id=None):
     return redirect(redirect_url)
 
 
-@posts_bp.route('/<username>/<post_id>/downvote', methods=['GET'])
-@posts_bp.route('/<username>/<post_id>/<reply_id>/downvote', methods=['GET'])
+@posts_bp.route('/<username>/<post_id>/downvote', methods=['POST'])
+@posts_bp.route('/<username>/<post_id>/<reply_id>/downvote', methods=['POST'])
 @login_required
 def downvote(username, post_id, reply_id=None):
     """Downvotes a post.
@@ -259,8 +259,8 @@ def downvote(username, post_id, reply_id=None):
     return redirect(redirect_url)
 
 
-@posts_bp.route('/<username>/<post_id>/delete', methods=['GET'])
-@posts_bp.route('/<username>/<post_id>/<reply_id>/delete', methods=['GET'])
+@posts_bp.route('/<username>/<post_id>/delete', methods=['POST'])
+@posts_bp.route('/<username>/<post_id>/<reply_id>/delete', methods=['POST'])
 @login_required
 def delete_post(username, post_id, reply_id=None):
     """Deletes posts.
@@ -298,7 +298,7 @@ def delete_post(username, post_id, reply_id=None):
     return redirect(redirect_url)
 
 
-@posts_bp.route('/<username>/<post_id>/unsubscribe', methods=['GET'])
+@posts_bp.route('/<username>/<post_id>/unsubscribe', methods=['POST'])
 @login_required
 def unsubscribe(username, post_id):
     """Unsubscribes a user from a post

--- a/pjuu/static/css/style.css
+++ b/pjuu/static/css/style.css
@@ -336,6 +336,7 @@ button:hover {
 
 .follow:hover {
     background-color: #3C3;
+    border: 1px solid #3C3;
     color: #FFF;
 }
 
@@ -349,6 +350,7 @@ button:hover {
 .unfollow:hover {
     background-color: #C00;
     border: 1px solid #C00;
+    color: #FFF;
     content: "Unfollow";
 }
 
@@ -583,6 +585,13 @@ button:hover {
     padding: 0;
 }
 
+#post button {
+    background: none !important;
+    border: none;
+    padding: 0 !important;
+    cursor: pointer;
+}
+
 /* AUTHOR ================================================================== */
 #author {
     border: 1px solid #666;
@@ -691,6 +700,13 @@ button:hover {
     list-style: none;
     margin: 0 0 0.5em 0;
     padding: 0.5em;
+}
+
+#list .item .buttonlink {
+    background: none !important;
+    border: none;
+    padding: 0 !important;
+    cursor: pointer;
 }
 
 #list .last {

--- a/pjuu/static/js/delete_confirmation.js
+++ b/pjuu/static/js/delete_confirmation.js
@@ -1,9 +1,8 @@
 /* Will ask a user to confirm via jQuery modal a deletion. */
 $(".delete").click(function(event) {
     event.stopPropagation();
-    var url = $(this).attr('href');
-    if(confirm("Do you want to delete this post?")) {
-        window.location = url;
+    var url = $(this).closest("form").attr("action");
+    if(!confirm("Do you want to delete this post?")) {
+        event.preventDefault();
     }
-    event.preventDefault();
 });

--- a/pjuu/templates/list_posts.html
+++ b/pjuu/templates/list_posts.html
@@ -14,12 +14,18 @@
             {% if config.TESTING %}
             <!-- delete:post:{{ item._id }} -->
             {% endif %}
-            <a href="{{ url_for('posts.delete_post', username=item.username, post_id=item._id, next=request.path + '?' + request.query_string) }}" class="fa fa-remove fa-lg delete"></a>
+            <form action="{{ url_for('posts.delete_post', username=item.username, post_id=item._id, next=request.path + '?' + request.query_string) }}" method="post">
+                <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                <button class="fa fa-remove fa-lg delete buttonlink"></button>
+            </form>
         {% elif request.endpoint == 'users.feed' %}
             {% if config.TESTING %}
             <!-- remove:post:{{ item._id }} -->
             {% endif %}
-            <a href="{{ url_for('users.remove_from_feed', post_id=item._id, next=request.path + '?' + request.query_string) }}" class="fa fa-eye-slash hide"></a>
+            <form action="{{ url_for('users.remove_from_feed', post_id=item._id, next=request.path + '?' + request.query_string) }}" method="post">
+                <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                <button class="fa fa-eye-slash hide buttonlink"></button>
+            </form>
         {% endif %}
     </div>
     <div class="content post clearfix">
@@ -61,7 +67,10 @@
                     {% if config.TESTING %}
                     <!-- upvote:post:{{ item._id }} -->
                     {% endif %}
-                    <a href="{{ url_for('posts.upvote', username=item.username, post_id=item._id, next=request.path + '?' + request.query_string) }}" class="fa fa-arrow-up fa-lg link upvote"></a>
+                    <form action="{{ url_for('posts.upvote', username=item.username, post_id=item._id, next=request.path + '?' + request.query_string) }}" method="post">
+                        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                        <button class="fa fa-arrow-up fa-lg link upvote buttonlink"></button>
+                    </form>
                     {% endif %}
                 </li>
                 <li>
@@ -76,7 +85,10 @@
                     {% if config.TESTING %}
                     <!-- downvote:post:{{ item._id }} -->
                     {% endif %}
-                    <a href="{{ url_for('posts.downvote', username=item.username, post_id=item._id, next=request.path + '?' + request.query_string) }}" class="fa fa-arrow-down fa-lg link downvote"></a>
+                    <form action="{{ url_for('posts.downvote', username=item.username, post_id=item._id, next=request.path + '?' + request.query_string) }}" method="post">
+                        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                        <button class="fa fa-arrow-down fa-lg link downvote buttonlink"></button>
+                    </form>
                     {% endif %}
                 </li>
                 {% endif %}

--- a/pjuu/templates/list_replies.html
+++ b/pjuu/templates/list_replies.html
@@ -13,7 +13,10 @@
         {% if config.TESTING %}
         <!-- delete:reply:{{ item._id }} -->
         {% endif %}
-        <a href="{{ url_for('posts.delete_post', username=post.username, post_id=item.reply_to, reply_id=item._id, next=request.path + '?' + request.query_string) }}" class="fa fa-remove fa-lg delete"></a>
+        <form action="{{ url_for('posts.delete_post', username=post.username, post_id=item.reply_to, reply_id=item._id, next=request.path + '?' + request.query_string) }}" method="post">
+            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+            <button class="fa fa-remove fa-lg delete buttonlink"></button>
+        </form>
         {% endif %}
     </div>
     <div class="content post clearfix">
@@ -55,7 +58,10 @@
                     {% if config.TESTING %}
                     <!-- upvote:reply:{{ item._id }} -->
                     {% endif %}
-                    <a href="{{ url_for('posts.upvote', username=post.username, post_id=item.reply_to, reply_id=item._id, next=request.path + '?' + request.query_string) }}" class="fa fa-arrow-up fa-lg link upvote"></a>
+                    <form action="{{ url_for('posts.upvote', username=post.username, post_id=item.reply_to, reply_id=item._id, next=request.path + '?' + request.query_string) }}" method="post">
+                        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                        <button class="fa fa-arrow-up fa-lg link upvote buttonlink"></button>
+                    </form>
                     {% endif %}
                 </li>
                 <li>
@@ -70,7 +76,10 @@
                     {% if config.TESTING %}
                     <!-- downvote:reply:{{ item._id }} -->
                     {% endif %}
-                    <a href="{{ url_for('posts.downvote', username=post.username, post_id=item.reply_to, reply_id=item._id, next=request.path + '?' + request.query_string) }}" class="fa fa-arrow-down fa-lg link downvote"></a>
+                    <form action="{{ url_for('posts.downvote', username=post.username, post_id=item.reply_to, reply_id=item._id, next=request.path + '?' + request.query_string) }}" method="post">
+                        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                        <button class="fa fa-arrow-down fa-lg link downvote buttonlink"></button>
+                    </form>
                     {% endif %}
                 </li>
                 {% endif %}

--- a/pjuu/templates/list_users.html
+++ b/pjuu/templates/list_users.html
@@ -14,13 +14,15 @@
             <div onmouseover="this.innerHTML = 'Edit'" onmouseout="this.innerHTML = 'You'" class="action you">You</div>
         </a>
         {% elif item|following %}
-        <a href="{{ url_for('users.unfollow', username=item.username, next=request.path + '?' + request.query_string) }}">
-            <div onmouseover="this.innerHTML = 'Unfollow'" onmouseout="this.innerHTML = 'Following'" class="action unfollow">Following</div>
-        </a>
+        <form action="{{ url_for('users.unfollow', username=item.username, next=request.path + '?' + request.query_string) }}" method="post">
+            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+            <button onmouseover="this.innerHTML = 'Unfollow'" onmouseout="this.innerHTML = 'Following'" class="action unfollow">Following</button>
+        </form>
         {% else %}
-        <a href="{{ url_for('users.follow', username=item.username, next=request.path + '?' + request.query_string) }}">
-            <div class="action follow">Follow</div>
-        </a>
+        <form action="{{ url_for('users.follow', username=item.username, next=request.path + '?' + request.query_string) }}" method="post">
+            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+            <button class="action follow">Follow</button>
+        </form>
         {% endif %}
     </div>
     <div class="content user clearfix">

--- a/pjuu/templates/profile.html
+++ b/pjuu/templates/profile.html
@@ -48,13 +48,15 @@
             <div onmouseover="this.innerHTML = 'Edit'" onmouseout="this.innerHTML = 'You'" class="action you">You</div>
         </a>
         {% elif profile|following %}
-        <a href="{{ url_for('users.unfollow', username=profile.username, next=request.path) }}">
-            <div onmouseover="this.innerHTML = 'Unfollow'" onmouseout="this.innerHTML = 'Following'" class="action unfollow">Following</div>
-        </a>
+        <form action="{{ url_for('users.unfollow', username=profile.username, next=request.path) }}" method="post">
+            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+            <button onmouseover="this.innerHTML = 'Unfollow'" onmouseout="this.innerHTML = 'Following'" class="action unfollow">Following</button>
+        </form>
         {% else %}
-        <a href="{{ url_for('users.follow', username=profile.username, next=request.path) }}">
-            <div class="action follow">Follow</div>
-        </a>
+        <form action="{{ url_for('users.follow', username=profile.username, next=request.path) }}" method="post">
+            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+            <button class="action follow">Follow</button>
+        </form>
         {% endif %}
     </div>
 </div>

--- a/pjuu/templates/view_post.html
+++ b/pjuu/templates/view_post.html
@@ -14,7 +14,10 @@
         {% if config.TESTING %}
         <!-- delete:post:{{ post._id }} -->
         {% endif %}
-        <a href="{{ url_for('posts.delete_post', username=post.username, post_id=post._id) }}" class="fa fa-remove fa-lg delete"></a>
+        <form action="{{ url_for('posts.delete_post', username=post.username, post_id=post._id) }}" method="post">
+            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+            <button class="fa fa-remove fa-lg delete"></button>
+        </form>
         {% endif %}
     </div>
 
@@ -56,7 +59,10 @@
                     {% if config.TESTING %}
                     <!-- upvote:post:{{ post._id }} -->
                     {% endif %}
-                    <a href="{{ url_for('posts.upvote', username=post.username, post_id=post._id, next=request.path) }}" class="fa fa-arrow-up fa-lg link upvote"></a>
+                    <form action="{{ url_for('posts.upvote', username=post.username, post_id=post._id, next=request.path) }}" method="post">
+                        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                        <button class="fa fa-arrow-up fa-lg link upvote"></button>
+                    </form>
                     {% endif %}
                 </li>
                 <li>
@@ -71,7 +77,10 @@
                     {% if config.TESTING %}
                     <!-- downvote:post:{{ post._id }} -->
                     {% endif %}
-                    <a href="{{ url_for('posts.downvote', username=post.username, post_id=post._id, next=request.path) }}" class="fa fa-arrow-down fa-lg link downvote"></a>
+                    <form action="{{ url_for('posts.downvote', username=post.username, post_id=post._id, next=request.path) }}" method="post">
+                        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                        <button class="fa fa-arrow-down fa-lg link downvote"></button>
+                    </form>
                     {% endif %}
                 </li>
                 {% endif %}
@@ -81,7 +90,10 @@
                 {% if config.TESTING %}
                 <!-- unsubscribe:post:{{ post._id }} -->
                 {% endif %}
-                <a href="{{ url_for('posts.unsubscribe', username=post.username, post_id=post._id, next=request.path + '?' + request.query_string) }}" class="fa fa-bell-slash fa-lg link unsubscribe"></a>
+                <form action="{{ url_for('posts.unsubscribe', username=post.username, post_id=post._id, next=request.path + '?' + request.query_string) }}" method="post">
+                    <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                    <button class="fa fa-bell-slash fa-lg link unsubscribe"></button>
+                </form>
             </div>
             {% endif %}
         </div>

--- a/pjuu/users/views.py
+++ b/pjuu/users/views.py
@@ -143,14 +143,16 @@ def feed():
                            post_form=post_form)
 
 
-@users_bp.route('/feed/<post_id>/remove', methods=['GET'])
+@users_bp.route('/feed/<post_id>/remove', methods=['POST'])
 @login_required
 def remove_from_feed(post_id):
-    """Removes ``post_id`` from current users feed"""
+    """Removes ``post_id`` from current users feed."""
+    redirect_url = handle_next(request, url_for('users.feed'))
+
     if be_remove_from_feed(post_id, current_user.get('_id')):
         flash('Message has been removed from feed', 'success')
 
-    return redirect(handle_next(request, url_for('users.feed')))
+    return redirect(handle_next(request, redirect_url))
 
 
 @users_bp.route('/<username>', methods=['GET'])
@@ -222,7 +224,7 @@ def followers(username):
                            pagination=_followers, post_form=post_form)
 
 
-@users_bp.route('/<username>/follow', methods=['GET'])
+@users_bp.route('/<username>/follow', methods=['POST'])
 @login_required
 def follow(username):
     """Follow a user."""
@@ -245,7 +247,7 @@ def follow(username):
     return redirect(redirect_url)
 
 
-@users_bp.route('/<username>/unfollow', methods=['GET'])
+@users_bp.route('/<username>/unfollow', methods=['POST'])
 @login_required
 def unfollow(username):
     """Unfollow a user"""

--- a/tests/test_posts_frontend.py
+++ b/tests/test_posts_frontend.py
@@ -571,9 +571,9 @@ class PostFrontendTests(FrontendTestCase):
         self.assertNotIn('<!-- downvoted:post:%s -->' % post2, resp.data)
 
         # Visit user 2's comment and UPVOTE that
-        resp = self.client.get(url_for('posts.upvote', username='user2',
-                                       post_id=post2),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.upvote', username='user2',
+                                        post_id=post2),
+                                follow_redirects=True)
         # We should now be at the posts page
         self.assertEqual(resp.status_code, 200)
         self.assertIn('You upvoted the post', resp.data)
@@ -585,9 +585,9 @@ class PostFrontendTests(FrontendTestCase):
         self.assertNotIn('<!-- downvoted:post:%s -->' % post2, resp.data)
 
         # Let's try and vote on that post again
-        resp = self.client.get(url_for('posts.upvote', username='user2',
-                                       post_id=post2),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.upvote', username='user2',
+                                        post_id=post2),
+                                follow_redirects=True)
         # We should now be at the posts page
         self.assertEqual(resp.status_code, 200)
         # Now that we have voted we should only see the arrow pointing to what
@@ -606,9 +606,9 @@ class PostFrontendTests(FrontendTestCase):
                       resp.data)
 
         # Down vote the users comment (it's nothing personal test2 :P)
-        resp = self.client.get(url_for('posts.downvote', username='user1',
-                                       post_id=post1, reply_id=comment1),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.downvote', username='user1',
+                                        post_id=post1, reply_id=comment1),
+                                follow_redirects=True)
         self.assertIn('You downvoted the comment', resp.data)
         self.assertIn('<!-- downvoted:reply:{0} -->'.format(comment1),
                       resp.data)
@@ -620,9 +620,9 @@ class PostFrontendTests(FrontendTestCase):
                          resp.data)
 
         # Lets check that we can't vote on this comment again
-        resp = self.client.get(url_for('posts.downvote', username='user1',
-                                       post_id=post1, reply_id=comment1),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.downvote', username='user1',
+                                        post_id=post1, reply_id=comment1),
+                                follow_redirects=True)
         self.assertIn('You have already voted on this post', resp.data)
 
         # Now lets double check we can't vote on our own comments or posts
@@ -635,31 +635,31 @@ class PostFrontendTests(FrontendTestCase):
         self.assertIn('Comment user 1', resp.data)
 
         # Lets ensure we can't vote on either the comment or the post
-        resp = self.client.get(url_for('posts.upvote', username='user1',
-                                       post_id=post3),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.upvote', username='user1',
+                                        post_id=post3),
+                                follow_redirects=True)
         self.assertIn('You can not vote on your own posts', resp.data)
 
-        resp = self.client.get(url_for('posts.upvote', username='user1',
-                                       post_id=post3, reply_id=comment2),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.upvote', username='user1',
+                                        post_id=post3, reply_id=comment2),
+                                follow_redirects=True)
         self.assertIn('You can not vote on your own posts', resp.data)
 
         # Try and vote on a comment or post that does not exist
         # Vote on a post
-        resp = self.client.get(url_for('posts.upvote', username='user1',
-                                       post_id=k.NIL_VALUE),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.upvote', username='user1',
+                                        post_id=k.NIL_VALUE),
+                                follow_redirects=True)
         self.assertEqual(resp.status_code, 404)
         # Vote on a comment
-        resp = self.client.get(url_for('posts.downvote', username='user1',
-                                       post_id=post3, reply_id=k.NIL_VALUE),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.downvote', username='user1',
+                                        post_id=post3, reply_id=k.NIL_VALUE),
+                                follow_redirects=True)
         self.assertEqual(resp.status_code, 404)
         # Vote on a post when the user doesn't even exists
-        resp = self.client.get(url_for('posts.downvote', username='userX',
-                                       post_id=post3, reply_id=k.NIL_VALUE),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.downvote', username='userX',
+                                        post_id=post3, reply_id=k.NIL_VALUE),
+                                follow_redirects=True)
         self.assertEqual(resp.status_code, 404)
 
         # Let's ensure a logged out user can not perform any of these actions
@@ -667,14 +667,14 @@ class PostFrontendTests(FrontendTestCase):
         self.client.get(url_for('auth.signout'), follow_redirects=True)
         # We are at the signin page
         # Vote on a post
-        resp = self.client.get(url_for('posts.upvote', username='user1',
-                                       post_id=post3),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.upvote', username='user1',
+                                        post_id=post3),
+                                follow_redirects=True)
         self.assertIn('You need to be logged in to view that', resp.data)
         # Vote on a comment
-        resp = self.client.get(url_for('posts.downvote', username='user1',
-                                       post_id=post3, reply_id=comment2),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.downvote', username='user1',
+                                        post_id=post3, reply_id=comment2),
+                                follow_redirects=True)
         self.assertIn('You need to be logged in to view that', resp.data)
 
         # Log in as user3 and try and catch some situations which are missing
@@ -684,15 +684,15 @@ class PostFrontendTests(FrontendTestCase):
             'password': 'Password'
         }, follow_redirects=True)
         # Downvote user1's post
-        resp = self.client.get(url_for('posts.downvote', username='user1',
-                                       post_id=post1),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.downvote', username='user1',
+                                        post_id=post1),
+                                follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         # Create a post and try and downvote it
         post4 = create_post(user3, 'user3', 'Test post')
-        resp = self.client.get(url_for('posts.downvote', username='user3',
-                                       post_id=post4),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.downvote', username='user3',
+                                        post_id=post4),
+                                follow_redirects=True)
         self.assertIn('You can not vote on your own posts', resp.data)
         # Done for now
 
@@ -730,8 +730,8 @@ class PostFrontendTests(FrontendTestCase):
         self.assertNotIn('<!-- delete:post:{0} -->'.format(post2), resp.data)
 
         # Try and delete user two's post this should fail
-        resp = self.client.get(url_for('posts.delete_post', username='user2',
-                                       post_id=post2))
+        resp = self.client.post(url_for('posts.delete_post', username='user2',
+                                        post_id=post2))
         self.assertEqual(resp.status_code, 403)
         # Ensure the post is still actuall there
         resp = self.client.get(url_for('posts.view_post', username='user2',
@@ -739,15 +739,15 @@ class PostFrontendTests(FrontendTestCase):
         self.assertIn('Test post, user 2', resp.data)
 
         # Try and delete a non-existant post
-        resp = self.client.get(url_for('posts.delete_post',
-                                       username=k.NIL_VALUE,
-                                       post_id=k.NIL_VALUE))
+        resp = self.client.post(url_for('posts.delete_post',
+                                        username=k.NIL_VALUE,
+                                        post_id=k.NIL_VALUE))
         self.assertEqual(resp.status_code, 404)
 
         # Let's delete our own post
-        resp = self.client.get(url_for('posts.delete_post', username='user1',
-                                       post_id=post1),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.delete_post', username='user1',
+                                        post_id=post1),
+                                follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         self.assertIn('Post has been deleted along with all replies',
                       resp.data)
@@ -777,9 +777,9 @@ class PostFrontendTests(FrontendTestCase):
                               post_id=post2, reply_id=comment1), resp.data)
 
         # Let's delete are own comment
-        resp = self.client.get(url_for('posts.delete_post', username='user2',
-                                       post_id=post2, reply_id=comment1),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.delete_post', username='user2',
+                                        post_id=post2, reply_id=comment1),
+                                follow_redirects=True)
         # Check we have confirmation
         self.assertIn('Post has been deleted', resp.data)
         # Lets check that comment 2 is there
@@ -790,15 +790,15 @@ class PostFrontendTests(FrontendTestCase):
 
         # Attempt to delete user 2's comment. This should fail with a 403
         # as we are neither the comment author nor the post author
-        resp = self.client.get(url_for('posts.delete_post', username='user2',
-                                       post_id=post2, reply_id=comment2),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.delete_post', username='user2',
+                                        post_id=post2, reply_id=comment2),
+                                follow_redirects=True)
         # Let's check we got the error
         self.assertEqual(resp.status_code, 403)
 
         # Attempt to delete user 2's post we should receive a 403
-        resp = self.client.get(url_for('posts.delete_post', username='user2',
-                                       post_id=post2, reply_id=comment2))
+        resp = self.client.post(url_for('posts.delete_post', username='user2',
+                                        post_id=post2, reply_id=comment2))
         self.assertEqual(resp.status_code, 403)
 
         # Let's just ensure the comment wasn't deleted
@@ -807,10 +807,10 @@ class PostFrontendTests(FrontendTestCase):
         self.assertIn('Test comment, user 2', resp.data)
 
         # Try and delete a non-existant comment
-        resp = self.client.get(url_for('posts.delete_post',
-                                       username=k.NIL_VALUE,
-                                       post_id=k.NIL_VALUE,
-                                       reply_id=k.NIL_VALUE))
+        resp = self.client.post(url_for('posts.delete_post',
+                                        username=k.NIL_VALUE,
+                                        post_id=k.NIL_VALUE,
+                                        reply_id=k.NIL_VALUE))
         self.assertEqual(resp.status_code, 404)
 
         # Log out as user 1
@@ -837,9 +837,9 @@ class PostFrontendTests(FrontendTestCase):
         # No need to test that test2 can delete there own post as we have
         # tested this already with test1.
         # Check that the owner of the post (user2) can delete any comment
-        resp = self.client.get(url_for('posts.delete_post', username='user2',
-                                       post_id=post2, reply_id=comment3),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.delete_post', username='user2',
+                                        post_id=post2, reply_id=comment3),
+                                follow_redirects=True)
         # Check we have confirmation
         self.assertIn('Post has been deleted', resp.data)
         # Lets check that comment 2 is there
@@ -888,9 +888,9 @@ class PostFrontendTests(FrontendTestCase):
 
         # Unsubscribe via the frontend and ensure the button is removed and
         # we get a flash message
-        resp = self.client.get(url_for('posts.unsubscribe', username='user1',
-                                       post_id=post1),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.unsubscribe', username='user1',
+                                        post_id=post1),
+                                follow_redirects=True)
         self.assertIn('You have been unsubscribed from this post', resp.data)
         self.assertNotIn('<!-- unsubscribe:post:{0} -->'.format(post1),
                          resp.data)
@@ -910,9 +910,9 @@ class PostFrontendTests(FrontendTestCase):
 
         # Check that unsubscribing from a non-existant (wont pass check post)
         # post will raise a 404
-        resp = self.client.get(url_for('posts.unsubscribe',
-                                       username=k.NIL_VALUE,
-                                       post_id=k.NIL_VALUE))
+        resp = self.client.post(url_for('posts.unsubscribe',
+                                        username=k.NIL_VALUE,
+                                        post_id=k.NIL_VALUE))
         self.assertEqual(resp.status_code, 404)
 
         # Log out aster user2
@@ -935,9 +935,9 @@ class PostFrontendTests(FrontendTestCase):
         # Create a post as user1 which we will not be subscribed too and ensure
         # that no message is shown
         post2 = create_post(user1, 'user1', "Test post, for cant unsubscribe")
-        resp = self.client.get(url_for('posts.unsubscribe', username='user1',
-                                       post_id=post2),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.unsubscribe', username='user1',
+                                        post_id=post2),
+                                follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         self.assertNotIn('You have been unsubscribed from this post',
                          resp.data)

--- a/tests/test_users_frontend.py
+++ b/tests/test_users_frontend.py
@@ -94,9 +94,10 @@ class FrontendTests(FrontendTestCase):
         # put we will check that there is at least one delete button
         self.assertIn('<!-- delete:post:', resp.data)
         # Delete the post
-        resp = self.client.get(url_for('posts.delete_post', username='user1',
-                               post_id=posts[100], next=url_for('users.feed')),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('posts.delete_post', username='user1',
+                                post_id=posts[100], next=url_for(
+                                    'users.feed')),
+                                follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         self.assertIn('User 1, Post 49!', resp.data)
         self.assertNotIn('User 1, Post 50!', resp.data)
@@ -119,11 +120,11 @@ class FrontendTests(FrontendTestCase):
 
         # Let's try and access the endpoints feature when we are not logged in
         # We should not be able to see it
-        resp = self.client.get(url_for('users.follow', username='user1'),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('users.follow', username='user1'),
+                                follow_redirects=True)
         self.assertIn('You need to be logged in to view that', resp.data)
-        resp = self.client.get(url_for('users.unfollow', username='user1'),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('users.unfollow', username='user1'),
+                                follow_redirects=True)
         self.assertIn('You need to be logged in to view that', resp.data)
         resp = self.client.get(url_for('users.following', username='user1'),
                                follow_redirects=True)
@@ -146,17 +147,17 @@ class FrontendTests(FrontendTestCase):
         resp = self.client.get(url_for('users.following', username='None'))
         self.assertEqual(resp.status_code, 404)
         # Try follow and unfollow a non-existant user
-        resp = self.client.get(url_for('users.follow', username='None'))
+        resp = self.client.post(url_for('users.follow', username='None'))
         self.assertEqual(resp.status_code, 404)
-        resp = self.client.get(url_for('users.unfollow', username='None'))
+        resp = self.client.post(url_for('users.unfollow', username='None'))
         self.assertEqual(resp.status_code, 404)
 
         # Try follow and unfollow yourself
-        resp = self.client.get(url_for('users.follow', username='user1'),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('users.follow', username='user1'),
+                                follow_redirects=True)
         self.assertIn('You can\'t follow/unfollow yourself', resp.data)
-        resp = self.client.get(url_for('users.unfollow', username='user1'),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('users.unfollow', username='user1'),
+                                follow_redirects=True)
         self.assertIn('You can\'t follow/unfollow yourself', resp.data)
 
         # Visit test2 and ensure followers count is 0
@@ -165,7 +166,7 @@ class FrontendTests(FrontendTestCase):
 
         # Follow test2
         # Ensure we pass a next variable to come back to test2's followers page
-        resp = self.client.get(url_for('users.follow', username='user2',
+        resp = self.client.post(url_for('users.follow', username='user2',
                                next=url_for('users.followers',
                                             username='user2')),
                                follow_redirects=True)
@@ -178,10 +179,10 @@ class FrontendTests(FrontendTestCase):
         self.assertIn('<!-- list:user:%s -->' % user1, resp.data)
 
         # Attempt to follow test2 again
-        resp = self.client.get(url_for('users.follow', username='user2',
-                               next=url_for('users.followers',
-                                            username='user2')),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('users.follow', username='user2',
+                                next=url_for('users.followers',
+                                             username='user2')),
+                                follow_redirects=True)
         # Check we got no confirmation
         self.assertNotIn('You have started following test2', resp.data)
         # Check that the followers count has not incremented
@@ -193,20 +194,20 @@ class FrontendTests(FrontendTestCase):
 
         # Unfollow test2
         # Ensure that all the previous has been reversed
-        resp = self.client.get(url_for('users.unfollow', username='user2',
-                               next=url_for('users.followers',
-                                            username='user2')),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('users.unfollow', username='user2',
+                                next=url_for('users.followers',
+                                             username='user2')),
+                                follow_redirects=True)
         self.assertIn('You are no longer following user2', resp.data)
         self.assertIn('<!-- followers:0 -->', resp.data)
         # Check the list testing tag has gone
         self.assertNotIn('<!-- list:user:test1 -->', resp.data)
 
         # Attempt to unfollow the user again
-        resp = self.client.get(url_for('users.unfollow', username='user2',
-                               next=url_for('users.followers',
-                                            username='user2')),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('users.unfollow', username='user2',
+                                next=url_for('users.followers',
+                                             username='user2')),
+                                follow_redirects=True)
         self.assertNotIn('You are no longer following user2', resp.data)
         self.assertIn('<!-- followers:0 -->', resp.data)
 
@@ -431,8 +432,9 @@ class FrontendTests(FrontendTestCase):
         self.assertIn('remove:post:{}'.format(post), resp.data)
 
         # Hide the post
-        resp = self.client.get(url_for('users.remove_from_feed', post_id=post),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('users.remove_from_feed',
+                                        post_id=post),
+                                follow_redirects=True)
 
         self.assertNotIn('User 2, is here', resp.data)
         self.assertNotIn('remove:post:{}'.format(post), resp.data)
@@ -447,15 +449,17 @@ class FrontendTests(FrontendTestCase):
         self.assertNotIn('remove:post:{}'.format(post), resp.data)
 
         # Ensure the URL hides the post
-        resp = self.client.get(url_for('users.remove_from_feed', post_id=post),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('users.remove_from_feed',
+                                        post_id=post),
+                                follow_redirects=True)
 
         self.assertNotIn('User 1, is here', resp.data)
         self.assertIn('Message has been removed from feed', resp.data)
 
         # Ensure removing a post that is not in your feed does not displau a
         # flash message
-        resp = self.client.get(url_for('users.remove_from_feed', post_id=''),
-                               follow_redirects=True)
+        resp = self.client.post(url_for('users.remove_from_feed',
+                                        post_id=''),
+                                follow_redirects=True)
 
         self.assertNotIn('Message has been removed from feed', resp.data)

--- a/tests/test_users_frontend.py
+++ b/tests/test_users_frontend.py
@@ -167,9 +167,9 @@ class FrontendTests(FrontendTestCase):
         # Follow test2
         # Ensure we pass a next variable to come back to test2's followers page
         resp = self.client.post(url_for('users.follow', username='user2',
-                               next=url_for('users.followers',
-                                            username='user2')),
-                               follow_redirects=True)
+                                next=url_for('users.followers',
+                                             username='user2')),
+                                follow_redirects=True)
         # Ensure the flash message has informed use we are following
         self.assertIn('You have started following user2', resp.data)
         # Ensure test2's followers count has been incremented


### PR DESCRIPTION
This work relates to issue #99. Some malicious sites could make you
perform an action you did not want to. This has now been removed.
All actions that affect your profile are now CSRF protected with POSTs.