### PR TITLE
Fix issues with avatar caching and pillow resizing.

### DIFF
--- a/pjuu/auth/backend.py
+++ b/pjuu/auth/backend.py
@@ -311,7 +311,7 @@ def delete_account(user_id):
 
     # If the user has an avatar remove it
     if user.get('avatar'):
-        delete_upload(user['avatar'], 'avatars')
+        delete_upload(user.get('avatar'))
 
     # Remove all posts a user has ever made. This includes all votes
     # on the posts and all comments of the posts.

--- a/pjuu/posts/backend.py
+++ b/pjuu/posts/backend.py
@@ -183,7 +183,7 @@ def create_post(user_id, username, body, reply_to=None, upload=None):
         # process_upload() can throw an Exception of UploadError. We will let
         # it fall through as a 500 is okay I think.
         # TODO: Turn this in to a Queue task at some point
-        filename = process_upload(post_id, upload)
+        filename = process_upload(upload)
 
         if filename is not None:
             # If the upload process was okay attach the filename to the doc
@@ -381,9 +381,9 @@ def get_post(post_id):
 
     if post is not None:
         user = m.db.users.find_one({'_id': post.get('user_id')},
-                                   {'email': True})
+                                   {'avatar': True})
         if user is not None:
-            post['user_email'] = user.get('email')
+            post['user_avatar'] = user.get('avatar')
 
     return post
 
@@ -395,7 +395,7 @@ def get_posts(user_id, page=1, per_page=None):
 
     # Get the user object we need the email for Gravatar.
     user = m.db.users.find_one({'_id': user_id},
-                               {'email': True})
+                               {'avatar': True})
 
     total = m.db.posts.find({
         'user_id': user_id,
@@ -409,7 +409,7 @@ def get_posts(user_id, page=1, per_page=None):
     for post in cursor:
         # This is not a nice solution but is needed for Gravatar
         if user is not None:  # pragma: no branch
-            post['user_email'] = user.get('email')
+            post['user_avatar'] = user.get('avatar')
 
         posts.append(post)
 
@@ -431,10 +431,10 @@ def get_replies(post_id, page=1, per_page=None):
         # We have to get the users email for each post for the gravatar
         user = m.db.users.find_one(
             {'_id': reply.get('user_id')},
-            {'email': True})
+            {'avatar': True})
 
         if user is not None:  # pragma: no branch
-            reply['user_email'] = user.get('email')
+            reply['user_avatar'] = user.get('avatar')
             replies.append(reply)
 
     return Pagination(replies, total, page, per_page)
@@ -457,10 +457,10 @@ def get_hashtagged_posts(hashtag, page=1, per_page=None):
     for post in cursor:
         user = m.db.users.find_one(
             {'_id': post.get('user_id')},
-            {'email': True})
+            {'avatar': True})
 
         if post is not None:  # pragma: no branch
-            post['user_email'] = user.get('email')
+            post['user_avatar'] = user.get('avatar')
             posts.append(post)
 
     return Pagination(posts, total, page, per_page)

--- a/pjuu/posts/views.py
+++ b/pjuu/posts/views.py
@@ -201,7 +201,6 @@ def post(username=None, post_id=None):
 
 
 @posts_bp.route('/uploads/<path:filename>', methods=['GET'])
-@login_required
 def get_upload(filename):
     """Simple function to get the uploaded content from GridFS.
 

--- a/pjuu/templates/list_alerts.html
+++ b/pjuu/templates/list_alerts.html
@@ -7,7 +7,11 @@
 <!-- list:alert:{{ item.alert_id }} -->
 {% endif %}
 <li class="item{% if loop.last %} last{% elif loop.first %} first{% endif %} alert clearfix">
-    <img class="avatar size48" src="{{ url_for('users.avatar', username=item.user.username) }}"/>
+    {% if item.user.avatar %}
+    <img class="avatar size48" src="{{ url_for('posts.get_upload', filename=item.user.avatar) }}"/>
+    {% else %}
+    <img class="avatar size48" src="{{ url_for('static', filename='img/otter_avatar.png') }}"/>
+    {% endif %}
     <div class="control">
         <a href="{{ url_for('users.delete_alert', alert_id=item.alert_id, next=request.path + '?' + request.query_string) }}" class="fa fa-eye-slash fa-lg hide"></a>
     </div>

--- a/pjuu/templates/list_posts.html
+++ b/pjuu/templates/list_posts.html
@@ -8,7 +8,11 @@
 <!-- list:post:{{item._id}} -->
 {% endif %}
 <li class="item{% if loop.last %} last{% endif %} clearfix">
-    <img class="avatar size48" src="{{ url_for('users.avatar', username=item.username) }}"/>
+    {% if item.user_avatar %}
+    <img class="avatar size48" src="{{ url_for('posts.get_upload', filename=item.user_avatar) }}"/>
+    {% else %}
+    <img class="avatar size48" src="{{ url_for('static', filename='img/otter_avatar.png') }}"/>
+    {% endif %}
     <div class="control">
         {% if item.user_id == current_user._id %}
             {% if config.TESTING %}

--- a/pjuu/templates/list_replies.html
+++ b/pjuu/templates/list_replies.html
@@ -7,7 +7,11 @@
 <!-- list:reply:{{item._id}} -->
 {% endif %}
 <li class="item{% if loop.last %} last{% endif %} clearfix">
-    <img class="avatar size48" src="{{ url_for('users.avatar', username=item.username) }}"/>
+    {% if item.user_avatar %}
+    <img class="avatar size48" src="{{ url_for('posts.get_upload', filename=item.user_avatar) }}"/>
+    {% else %}
+    <img class="avatar size48" src="{{ url_for('static', filename='img/otter_avatar.png') }}"/>
+    {% endif %}
     <div class="control">
         {% if item.user_id == current_user._id or post.username == current_user.username %}
         {% if config.TESTING %}

--- a/pjuu/templates/list_users.html
+++ b/pjuu/templates/list_users.html
@@ -7,7 +7,11 @@
 <!-- list:user:{{item._id}} -->
 {% endif %}
 <li class="item{% if loop.last %} last{% elif loop.first %} first{% endif %} user clearfix">
-    <img class="avatar size48" src="{{ url_for('users.avatar', username=item.username) }}"/>
+    {% if item.avatar %}
+    <img class="avatar size48" src="{{ url_for('posts.get_upload', filename=item.avatar) }}"/>
+    {% else %}
+    <img class="avatar size48" src="{{ url_for('static', filename='img/otter_avatar.png') }}"/>
+    {% endif %}
     <div class="control">
         {% if item._id == current_user._id %}
         <a href="{{ url_for('users.settings_profile') }}">

--- a/pjuu/templates/profile.html
+++ b/pjuu/templates/profile.html
@@ -5,7 +5,12 @@
 {% block main %}
 <div id="profile" class="block clearfix">
     <div class="top clearfix">
-        <img class="avatar size48" src="{{ url_for('users.avatar', username=profile.username) }}"/>
+        {% if profile.avatar %}
+        <img class="avatar size48" src="{{ url_for('posts.get_upload', filename=profile.avatar) }}"/>
+        {% else %}
+        <img class="avatar size48" src="{{ url_for('static', filename='img/otter_avatar.png') }}"/>
+        {% endif %}
+
         <div class="content clearfix">
                 <div class="username">
                     {{ profile.username|capitalize }}

--- a/pjuu/templates/settings_profile.html
+++ b/pjuu/templates/settings_profile.html
@@ -31,7 +31,13 @@
                         <!-- user:avatar:default -->
                         {% endif %}
                     {% endif %}
-                    <div><img src="{{ url_for('users.avatar', username=current_user.username) }}" /></div>
+                    <div>
+                        {% if current_user.avatar %}
+                        <img class="size96" src="{{ url_for('posts.get_upload', filename=current_user.avatar) }}" />
+                        {% else %}
+                        <img class="size96" src="{{ url_for('static', filename='img/otter_avatar.png') }}" />
+                        {% endif %}
+                    </div>
                     <div class="clearfix">
                         <label id="upload-label" for="upload" style="display: none;">
                             {{ form.upload(accept='image/*') }}

--- a/pjuu/templates/view_post.html
+++ b/pjuu/templates/view_post.html
@@ -7,7 +7,11 @@
 <!-- view:post:{{ post._id }} -->
 {% endif %}
 <div id="post" class="block clearfix">
-    <img class="avatar size48" src="{{ url_for('users.avatar', username=post.username) }}"/>
+    {% if post.user_avatar %}
+    <img class="avatar size48" src="{{ url_for('posts.get_upload', filename=post.user_avatar) }}"/>
+    {% else %}
+    <img class="avatar size48" src="{{ url_for('static', filename='img/otter_avatar.png') }}"/>
+    {% endif %}
 
     <div class="control">
         {% if post.user_id == current_user._id %}

--- a/pjuu/users/views.py
+++ b/pjuu/users/views.py
@@ -12,14 +12,13 @@ from datetime import datetime
 import math
 # 3rd party imports
 from flask import (abort, flash, redirect, render_template, request, url_for,
-                   Blueprint, current_app as app, send_file)
+                   Blueprint, current_app as app)
 # Pjuu imports
 from pjuu.auth import current_user
-from pjuu.auth.utils import get_uid, get_uid_username, get_user
+from pjuu.auth.utils import get_uid, get_uid_username
 from pjuu.auth.decorators import login_required
 from pjuu.lib import handle_next, timestamp
 from pjuu.lib.pagination import handle_page
-from pjuu.lib.uploads import get_upload
 from pjuu.posts.backend import get_posts
 from pjuu.posts.forms import PostForm
 from pjuu.users.forms import ChangeProfileForm, SearchForm
@@ -175,22 +174,6 @@ def profile(username):
     post_form = PostForm()
     return render_template('posts.html', profile=_profile,
                            pagination=pagination, post_form=post_form)
-
-
-@users_bp.route('/<username>/avatar', methods=['GET'])
-@login_required
-def avatar(username):
-    """Return the users avatar image or the dafault."""
-    # Get the user
-    user = get_user(get_uid_username(username))
-
-    # If the user has an avatar set then get it from GridFS
-    if user.get('avatar') is not None:
-        return get_upload(user.get('avatar'), cache_for=0,
-                          collection='avatars')
-
-    # The user doesn't have one send them the default
-    return send_file('static/img/otter_avatar.png', cache_timeout=0)
 
 
 @users_bp.route('/<username>/following', methods=['GET'])

--- a/scripts/avatar_migration_09.py
+++ b/scripts/avatar_migration_09.py
@@ -1,0 +1,36 @@
+# -*- coding: utf8 -*-
+
+"""Moved the avatars form the `avatars` collection back to `uploads`.
+
+:license: AGPL v3, see LICENSE for more details
+:copyright: 2014-2015 Joe Doherty
+
+"""
+
+import io
+import gridfs
+from PIL import Image as PILImage
+import pymongo
+
+
+m = pymongo.MongoClient(host='127.0.0.1')
+
+
+if __name__ == '__main__':
+    out_grid = gridfs.GridFS(m.pjuu, collection='avatars')
+    in_grid = gridfs.GridFS(m.pjuu, collection='uploads')
+
+    for f in out_grid.find():
+        out_file = out_grid.get(f._id)
+
+        # Ensure the avatar is the correct size.
+        output = io.BytesIO()
+
+        img = PILImage.open(out_file)
+        img = img.resize((96, 96), PILImage.ANTIALIAS)
+        img.save(output, format='PNG', quality=100)
+        output.seek(0)
+
+        in_grid.put(output, filename=out_file.filename,
+                    content_type=out_file.contentType)
+        out_grid.delete(out_file._id)

--- a/tests/test_posts_frontend.py
+++ b/tests/test_posts_frontend.py
@@ -300,11 +300,11 @@ class PostFrontendTests(FrontendTestCase):
 
         post = get_post(post1)
 
-        # Try and get the post and ensure we are redirected because we are not
-        # logged in
+        # You can download an upload when you are NOT logged in
+        # This allows web tier caching
         resp = self.client.get(url_for('posts.get_upload',
                                        filename=post.get('upload')))
-        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.status_code, 200)
 
         # Log in as user1 and get the upload
         resp = self.client.post(url_for('auth.signin'), data={

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -13,7 +13,6 @@ from os import listdir
 from os.path import isfile, join
 
 from pjuu import mongo as m
-from pjuu.lib import get_uuid
 from pjuu.lib.uploads import process_upload, get_upload, delete_upload
 
 from tests import FrontendTestCase
@@ -39,13 +38,10 @@ class PagesTests(FrontendTestCase):
 
         # Test each file in the upload directory
         for f in test_upload_files:
-            uuid = get_uuid()
             image = io.BytesIO(
                 open(f).read()
             )
-            filename = process_upload(uuid, image)
-
-            self.assertEqual(filename, '{}.png'.format(uuid))
+            filename = process_upload(image)
 
             # Get the upload these are designed for being served directly by
             # Flask. This is a Flask/Werkzeug response object
@@ -62,6 +58,5 @@ class PagesTests(FrontendTestCase):
             self.assertFalse(grid.exists({'filename': filename}))
 
         # Ensure that if we load a non-image file a None value is returned
-        uuid = get_uuid()
         image = io.BytesIO()
-        self.assertIsNone(process_upload(uuid, image))
+        self.assertIsNone(process_upload(image))

--- a/tests/test_users_frontend.py
+++ b/tests/test_users_frontend.py
@@ -543,12 +543,14 @@ class FrontendTests(FrontendTestCase):
         resp = self.client.get(url_for('users.settings_profile',
                                username='user1'))
         self.assertIn('<!-- user:avatar:default -->', resp.data)
-        self.assertIn(url_for('users.avatar', username='user1'), resp.data)
+        self.assertIn(url_for('static', filename='img/otter_avatar.png'),
+                      resp.data)
 
         # Check the avatar for the default
         # We can't inspect it
-        resp = self.client.get(url_for('users.avatar',
-                               username='user1'))
+        user = get_user(user1)
+        resp = self.client.get(url_for('static',
+                                       filename='img/otter_avatar.png'))
         self.assertEqual(resp.status_code, 200)
 
         # Get the users object to check some things
@@ -570,12 +572,12 @@ class FrontendTests(FrontendTestCase):
         self.assertIn('<!-- user:avatar:{} -->'.format(user.get('avatar')),
                       resp.data)
 
-        grid = gridfs.GridFS(m.db, collection='avatars')
+        grid = gridfs.GridFS(m.db, collection='uploads')
         self.assertEqual(grid.find({'filename': user.get('avatar')}).count(),
                          1)
 
-        resp = self.client.get(url_for('users.avatar',
-                               username='user1'))
+        resp = self.client.get(url_for('posts.get_upload',
+                               filename=user.get('avatar')))
         self.assertEqual(resp.status_code, 200)
 
         # upload another and ensure there is only one in GridFs


### PR DESCRIPTION
- Pillow resize was added rather than thumbnail as it was keeping aspect
  rather than making an odd sized avatar exactly 96x96.
- Removed the need to be logged in to Pjuu to see uploaded content. This
  allows caching at a web tier such as Nginx, Apache, etc.
- So that upload URLs are not the same name as there assoicated objects
  ID. Each upload is assigned a new UUID seperate to that of the post or
  user.

This has caused a load of changes to templates as now, instead of the
users e-mail being pulled in to each post the avatar is now brought in
instead.

This has opened up the ground work to a load more optimisations which
can/need to be made.