### PR TITLE
Hashtag search and search modifiers `#` and `@`.

### DIFF
--- a/pjuu/auth/views.py
+++ b/pjuu/auth/views.py
@@ -7,14 +7,12 @@
 
 """
 
-import time
-
 # 3rd party imports
 from flask import (current_app as app, flash, redirect, render_template,
                    request, url_for, session, jsonify, Blueprint, g,
                    _app_ctx_stack)
 # Pjuu imports
-from pjuu.lib import handle_next
+from pjuu.lib import handle_next, timestamp
 from pjuu.lib.mail import send_mail
 from pjuu.lib.tokens import generate_token, check_token
 from pjuu.auth import current_user
@@ -69,14 +67,14 @@ def kick_banned_user():
 def gather_time():
     """This is used to measure the request time for each page"""
     if app.debug and not app.testing:  # pragma: no cover
-        g.start_time = time.time()
+        g.start_time = timestamp()
 
 
 @auth_bp.after_request
 def display_time(response):
     """This is will write the time to the console in DEBUG mode"""
     if app.debug and not app.testing:  # pragma: no cover
-        print time.time() - g.start_time, 'secs'
+        print timestamp() - g.start_time, 'secs'
     return response
 
 

--- a/pjuu/settings.py
+++ b/pjuu/settings.py
@@ -72,3 +72,6 @@ SENTRY_DSN = ''
 FEED_ITEMS_PER_PAGE = 25
 REPLIES_ITEMS_PER_PAGE = 25
 ALERT_ITEMS_PER_PAGE = 50
+
+# Max search items is needed to work pagination across search terms
+MAX_SEARCH_ITEMS = 500

--- a/pjuu/templates/list.html
+++ b/pjuu/templates/list.html
@@ -29,13 +29,13 @@
         {% if config.TESTING %}
         <!-- pagination:newest -->
         {% endif %}
-        <a href="{{ request.path + "?page=%s" % pagination.first_page }}">
+        <a href="{{ url_for(request.endpoint, **dict(request.view_args.items() + request.args.items() + [('page', pagination.first_page)])) }}">
             <i class="fa fa-angle-double-left"></i>
         </a>
         {% if config.TESTING %}
         <!-- pagination:newer -->
         {% endif %}
-        <a href="{{ request.path + "?page=%s" % pagination.prev_page }}">
+        <a href="{{ url_for(request.endpoint, **dict(request.view_args.items() + request.args.items() + [('page', pagination.prev_page)])) }}">
             <i class="fa fa-angle-left"></i>
         </a>
     </div>
@@ -45,13 +45,13 @@
         {% if config.TESTING %}
         <!-- pagination:older -->
         {% endif %}
-        <a href="{{ request.path + "?page=%s" % pagination.next_page }}">
+        <a href="{{ url_for(request.endpoint, **dict(request.view_args.items() + request.args.items() + [('page', pagination.next_page)])) }}">
             <i class="fa fa-angle-right"></i>
         </a>
         {% if config.TESTING %}
         <!-- pagination:oldest -->
         {% endif %}
-        <a href="{{ request.path + "?page=%s" % pagination.last_page }}">
+        <a href="{{ url_for(request.endpoint, **dict(request.view_args.items() + request.args.items() + [('page', pagination.last_page)])) }}">
             <i class="fa fa-angle-double-right"></i>
         </a>
     </div>

--- a/pjuu/users/views.py
+++ b/pjuu/users/views.py
@@ -279,12 +279,17 @@ def search():
 
     .. note: Should be _NO_ CSRF this will appear in the URL and look shit.
     """
+    # Pagination
+    page = handle_page(request)
+
     form = SearchForm(request.form)
 
     # Get the query string. If its not there return an empty string
     query = request.args.get('query', '')
 
-    _results = be_search(query)
+    _results = be_search(query, page,
+                         current_user.get('feed_pagination_size'))
+
     return render_template('search.html', form=form, query=query,
                            pagination=_results)
 


### PR DESCRIPTION
Hashtags will now show up in the search. If a user just wants to search
for users on there own the search can be prefixed with `@`. If only
hashtags are wanted then the prefix `#` can be used.

Closes #137.