### PR TITLE
Remove multiple calles to `voted` filter.

### DIFF
--- a/pjuu/templates/list_post.html
+++ b/pjuu/templates/list_post.html
@@ -63,13 +63,14 @@
                     {{ item.score|millify }}
                 </li>
                 {% if item.user_id != current_user._id %}
+                {% set voted_on = item._id|voted %}
                 <li>
-                    {% if item._id|voted > 0 %}
+                    {% if voted_on > 0 %}
                     {% if config.TESTING %}
                     <!-- upvoted:post:{{ item._id }} -->
                     {% endif %}
                     <i class="fa fa-arrow-up fa-lg upvoted"></i>
-                    {% elif item._id|voted < 0 %}
+                    {% elif voted_on < 0 %}
                     <i class="fa fa-arrow-up fa-lg inactive"></i>
                     {% else %}
                     {% if config.TESTING %}
@@ -82,12 +83,12 @@
                     {% endif %}
                 </li>
                 <li>
-                    {% if item._id|voted < 0 %}
+                    {% if voted_on < 0 %}
                     {% if config.TESTING %}
                     <!-- downvoted:post:{{ item._id }} -->
                     {% endif %}
                     <i class="fa fa-arrow-down fa-lg downvoted"></i>
-                    {% elif item._id|voted > 0 %}
+                    {% elif voted_on > 0 %}
                     <i class="fa fa-arrow-down fa-lg inactive"></i>
                     {% else %}
                     {% if config.TESTING %}

--- a/pjuu/templates/list_reply.html
+++ b/pjuu/templates/list_reply.html
@@ -46,13 +46,14 @@
                     {{ item.score|millify }}
                 </li>
                 {% if item.user_id != current_user._id %}
+                {% set voted_on = item._id|voted %}
                 <li>
-                    {% if item._id|voted > 0 %}
+                    {% if voted_on > 0 %}
                     {% if config.TESTING %}
                     <!-- upvoted:reply:{{ item._id }} -->
                     {% endif %}
                     <i class="fa fa-arrow-up fa-lg upvoted"></i>
-                    {% elif item._id|voted < 0 %}
+                    {% elif voted_on < 0 %}
                     <i class="fa fa-arrow-up fa-lg inactive"></i>
                     {% else %}
                     {% if config.TESTING %}
@@ -65,12 +66,12 @@
                     {% endif %}
                 </li>
                 <li>
-                    {% if item._id|voted < 0 %}
+                    {% if voted_on < 0 %}
                     {% if config.TESTING %}
                     <!-- downvoted:reply:{{ item._id }} -->
                     {% endif %}
                     <i class="fa fa-arrow-down fa-lg downvoted"></i>
-                    {% elif item._id|voted > 0 %}
+                    {% elif voted_on > 0 %}
                     <i class="fa fa-arrow-down fa-lg inactive"></i>
                     {% else %}
                     {% if config.TESTING %}

--- a/pjuu/templates/view_post.html
+++ b/pjuu/templates/view_post.html
@@ -51,13 +51,14 @@
                     <i class="fa fa-trophy fa-lg"></i> {{ post.score|millify }}
                 </li>
                 {% if post.user_id != current_user._id %}
+                {% set voted_on = post._id|voted %}
                 <li>
-                    {% if post._id|voted > 0 %}
+                    {% if voted_on > 0 %}
                     {% if config.TESTING %}
                     <!-- upvoted:post:{{ post._id }} -->
                     {% endif %}
                     <i class="fa fa-arrow-up fa-lg upvoted"></i>
-                    {% elif post._id|voted < 0 %}
+                    {% elif voted_on < 0 %}
                     <i class="fa fa-arrow-up fa-lg inactive"></i>
                     {% else %}
                     {% if config.TESTING %}
@@ -70,12 +71,12 @@
                     {% endif %}
                 </li>
                 <li>
-                    {% if post._id|voted < 0 %}
+                    {% if voted_on < 0 %}
                     {% if config.TESTING %}
                     <!-- downvoted:post:{{ post._id }} -->
                     {% endif %}
                     <i class="fa fa-arrow-down fa-lg downvoted"></i>
-                    {% elif post._id|voted > 0 %}
+                    {% elif voted_on > 0 %}
                     <i class="fa fa-arrow-down fa-lg inactive"></i>
                     {% else %}
                     {% if config.TESTING %}


### PR DESCRIPTION
When rendering posts there is a lot of checking in Redis to see if the
user has voted.

It was calling this everytime when trying to work out which way someone
voted.

This is now set in a Jinja2 variable.