### PR TITLE
Hide inactive users from search and tagging.

### DIFF
--- a/pjuu/__init__.py
+++ b/pjuu/__init__.py
@@ -112,7 +112,7 @@ def create_app(config_filename='settings.py', config_dict=None):
         if app.debug and not app.testing:  # pragma: no cover
             if request.endpoint != 'static':
                 print request.path, request.endpoint, \
-                      str((timestamp() - g.start_time) * 100) + 'ms'
+                    str((timestamp() - g.start_time) * 100) + 'ms'
         return response
 
     @app.url_defaults

--- a/pjuu/auth/stats.py
+++ b/pjuu/auth/stats.py
@@ -25,14 +25,21 @@ def get_stats():
     total_op = m.db.users.find({'op': True}).count()
 
     newest_users_cur = m.db.users.find(
-        {}, {'_id': False, 'username': True}
+        {}, {'_id': False, 'username': True, 'active': True}
     ).sort(
         [('created', pymongo.DESCENDING)]
-    ).limit(5)
+    ).limit(10)
     newest_users = []
     for user in newest_users_cur:
-        link = '<a href="{0}">{1}</a>'.format(
+        # If the user is active show a green circle else red
+        if user.get('active'):
+            active_string = 'green'
+        else:
+            active_string = 'red'
+
+        link = '<a href="{0}"><i class="fa fa-circle {1}"></i> {2}</a>'.format(
             url_for('users.profile', username=user.get('username')),
+            active_string,
             user.get('username')
         )
         newest_users.append(link)

--- a/pjuu/auth/utils.py
+++ b/pjuu/auth/utils.py
@@ -12,17 +12,26 @@ circular imports.
 from pjuu import mongo as m
 
 
-def get_uid_username(username):
+def get_uid_username(username, non_active=False):
     """Find a uid given a username.
 
     :param username: The username to lookup
     :type username: str
+    :param non_active: Allow looking up non-active users
+    :type non_active: bool
     :returns: The users UID
     :rtype: str or None
 
     """
     # Will return the user object with on the _id (user_id) field
-    user = m.db.users.find_one({'username': username.lower()}, {})
+    query_dict = {
+        'username': username.lower()
+    }
+
+    if not non_active:
+        query_dict['active'] = True
+
+    user = m.db.users.find_one(query_dict, {})
 
     if user is not None:
         return user.get('_id')
@@ -30,17 +39,26 @@ def get_uid_username(username):
     return None
 
 
-def get_uid_email(email):
+def get_uid_email(email, non_active=False):
     """Find a uid given a username.
 
     :param email: The email to lookup
     :type email: str
+    :param non_active: Allow looking up non-active users
+    :type non_active: bool
     :returns: The users UID
     :rtype: str or None
 
     """
+    query_dict = {
+        'email': email.lower()
+    }
+
+    if not non_active:
+        query_dict['active'] = True
+
     # Look up the email inside mongo
-    uid = m.db.users.find_one({'email': email.lower()}, {})
+    uid = m.db.users.find_one(query_dict, {})
 
     if uid is not None:
         return uid.get('_id')
@@ -48,20 +66,22 @@ def get_uid_email(email):
     return None
 
 
-def get_uid(lookup_value):
+def get_uid(lookup_value, non_active=False):
     """Calls either `get_uid_username` or `get_uid_email` depending on the
     the contents of `lookup_value`.
 
     :param lookup_value: The value to lookup
     :type lookup_value: str
+    :param non_active: Allow looking up non-active users
+    :type non_active: bool
     :returns: The users UID
     :rtype: str or None
 
     """
     if '@' in lookup_value:
-        return get_uid_email(lookup_value)
+        return get_uid_email(lookup_value, non_active=non_active)
     else:
-        return get_uid_username(lookup_value)
+        return get_uid_username(lookup_value, non_active=non_active)
 
 
 def get_user(user_id):

--- a/pjuu/auth/views.py
+++ b/pjuu/auth/views.py
@@ -201,12 +201,11 @@ def activate(token):
 @auth_bp.route('/forgot', methods=['GET', 'POST'])
 @anonymous_required
 def forgot():
-    """
-    """
+    """Allow users to get a password reset link"""
     form = ForgotForm(request.form)
     # We always go to /signin after a POST
     if request.method == 'POST':
-        user = get_user(get_uid(form.username.data))
+        user = get_user(get_uid(form.username.data, non_active=True))
         if user is not None:
             # Only send e-mails to user which exist.
             token = generate_token({'action': 'reset', 'uid': user.get('_id')})

--- a/pjuu/static/css/style.css
+++ b/pjuu/static/css/style.css
@@ -1001,6 +1001,14 @@ input[type="file"] {
     cursor: pointer;
 }
 
+.red {
+    color: #F00;
+}
+
+.green {
+    color: #0F0;
+}
+
 /* FOOTER ================================================================== */
 #footer {
     margin: 2em 0 0.5em 0;

--- a/pjuu/static/js/pjuu.js
+++ b/pjuu/static/js/pjuu.js
@@ -67,7 +67,7 @@ $(document).ready(function() {
      * Handle checking for new alerts
      */
     // The amount of time between checking for alerts
-    var alert_timeout = 5000;
+    var alert_timeout = 30000;
 
     // This uses a timeout so that if it fails (auth pages) it won't bother
     // trying agin until the page is refreshed.

--- a/pjuu/users/backend.py
+++ b/pjuu/users/backend.py
@@ -221,32 +221,29 @@ def search(query, page=1, per_page=None):
         total = 0
 
         if users:
-            total += m.db.users.find({
-                'username': {'$regex': '^{}'.format(query)}
-            }).count()
-
             # We will concatenate the glob pattern to the query
             cursor = m.db.users.find({
-                'username': {'$regex': '^{}'.format(query)}
+                'username': {'$regex': '^{}'.format(query)},
+                'active': True
             }).sort(
                 'username', pymongo.ASCENDING
             ).limit(max_items)
+
+            # You can count the length of the cursor
+            total += cursor.count()
 
             for user in cursor:
                 results.append(user)
 
         if hashtags:
-            total += m.db.posts.find({
-                'hashtags.hashtag': {'$regex': '^{}'.format(query)},
-                'reply_to': {'$exists': False}
-            }).count()
-
             cursor = m.db.posts.find({
                 'hashtags.hashtag': {'$regex': '^{}'.format(query)},
                 'reply_to': {'$exists': False}
             }).sort(
                 'hashtags.hashtag', pymongo.ASCENDING
             ).limit(max_items)
+
+            total += cursor.count()
 
             for hashtag in cursor:
                 results.append(hashtag)

--- a/tests/test_auth_backend.py
+++ b/tests/test_auth_backend.py
@@ -60,7 +60,10 @@ class AuthBackendTests(BackendTestCase):
         self.assertIsNone(
             create_account('help', 'userX@pjuu.com', 'Password'))
 
-        # Check lookup keys exist
+        # You can't get a UID for a non-activated user
+        self.assertEqual(get_uid('user1'), None)
+
+        activate(user1)
         self.assertEqual(get_uid('user1'), user1)
         self.assertEqual(get_uid('user1@pjuu.com'), user1)
 
@@ -82,13 +85,16 @@ class AuthBackendTests(BackendTestCase):
         self.assertEqual(get_uid_username('user1'), user1)
         self.assertEqual(get_uid_email('user1@pjuu.com'), user1)
 
+        # Create a new user to check the defaults
+        user2 = create_account('user2', 'user2@pjuu.com', 'Password')
+
         # Are values set as expected?
-        user = get_user(user1)
+        user = get_user(user2)
 
         self.assertIsNotNone(user)
-        self.assertEqual(user.get('_id'), user1)
-        self.assertEqual(user.get('username'), 'user1')
-        self.assertEqual(user.get('email'), 'user1@pjuu.com')
+        self.assertEqual(user.get('_id'), user2)
+        self.assertEqual(user.get('username'), 'user2')
+        self.assertEqual(user.get('email'), 'user2@pjuu.com')
         self.assertEqual(user.get('last_login'), -1)
         self.assertFalse(user.get('active'))
         self.assertFalse(user.get('banned'))
@@ -243,6 +249,9 @@ class AuthBackendTests(BackendTestCase):
         user1 = create_account('user1', 'user1@pjuu.com', 'Password')
 
         # Test email lookup key
+        self.assertEqual(get_uid_email('user1@pjuu.com'), None)
+
+        activate(user1)
         self.assertEqual(get_uid_email('user1@pjuu.com'), user1)
         # Check correct email
         self.assertEqual(get_user(user1).get('email'), 'user1@pjuu.com')

--- a/tests/test_auth_frontend.py
+++ b/tests/test_auth_frontend.py
@@ -314,6 +314,14 @@ class AuthFrontendTests(FrontendTestCase):
         # not be generated for a non existant user
         self.assertIsNone(resp.headers.get('X-Pjuu-Token'))
 
+        # Same test with e-mail
+        resp = self.client.post(url_for('auth.forgot'), data={
+            'username': 'user1@pjuu.com'
+        }, follow_redirects=True)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('If we\'ve found your account we\'ve', resp.data)
+        self.assertIsNone(resp.headers.get('X-Pjuu-Token'))
+
         # Lets do this again but with a user (this is the only way to test
         # password resetting)
         create_account('user1', 'user1@pjuu.com', 'Password')
@@ -325,6 +333,15 @@ class AuthFrontendTests(FrontendTestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn('If we\'ve found your account we\'ve', resp.data)
         # This time we should have a token
+        token = resp.headers.get('X-Pjuu-Token')
+        self.assertIsNotNone(token)
+
+        # Same test with e-mail
+        resp = self.client.post(url_for('auth.forgot'), data={
+            'username': 'user1@pjuu.com'
+        }, follow_redirects=True)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('If we\'ve found your account we\'ve', resp.data)
         token = resp.headers.get('X-Pjuu-Token')
         self.assertIsNotNone(token)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -7,7 +7,7 @@
 
 """
 
-from pjuu.auth.backend import create_account
+from pjuu.auth.backend import create_account, activate
 from pjuu.lib.parser import (parse_hashtags, parse_links, parse_mentions,
                              parse_post)
 
@@ -78,6 +78,7 @@ class ParserTests(BackendTestCase):
     def test_mention_real_user(self):
         """Find a user mentions (user does exist)"""
         user1 = create_account('user1', 'user1@pjuu.com', 'Password1')
+        activate(user1)
         mentions = parse_mentions('@user1 @user2')
         self.assertEqual(len(mentions), 1)
         self.assertEqual(mentions[0]['username'], 'user1')
@@ -86,7 +87,8 @@ class ParserTests(BackendTestCase):
 
     def test_unicode_character(self):
         """Do unicode characters break things."""
-        create_account('user1', 'user1@pjuu.com', 'Password1')
+        user1 = create_account('user1', 'user1@pjuu.com', 'Password1')
+        activate(user1)
         links, mentions, hashtags = parse_post('၍ @user1, ☂pjuu.com, 㒅 #hash')
         self.assertEqual(links[0]['link'], 'http://pjuu.com')
         self.assertEqual(mentions[0]['username'], 'user1')
@@ -94,7 +96,8 @@ class ParserTests(BackendTestCase):
 
     def test_surrounding_characters(self):
         """Can parse objects be in parenthesis"""
-        create_account('user1', 'user1@pjuu.com', 'Password1')
+        user1 = create_account('user1', 'user1@pjuu.com', 'Password1')
+        activate(user1)
         links, mentions, hashtags = parse_post('(@user1), (pjuu.com), (#hash)')
         self.assertEqual(links[0]['link'], 'http://pjuu.com')
         self.assertEqual(mentions[0]['username'], 'user1')

--- a/tests/test_posts_backend.py
+++ b/tests/test_posts_backend.py
@@ -13,7 +13,7 @@ import gridfs
 from flask import current_app as app
 
 from pjuu import mongo as m, redis as r
-from pjuu.auth.backend import create_account, delete_account
+from pjuu.auth.backend import create_account, delete_account, activate
 from pjuu.auth.utils import get_user
 from pjuu.lib import keys as K
 from pjuu.posts.backend import (
@@ -481,6 +481,10 @@ class PostBackendTests(BackendTestCase):
         user2 = create_account('user2', 'user2@pjuu.com', 'Password')
         user3 = create_account('user3', 'user3@pjuu.com', 'Password')
 
+        activate(user1)
+        activate(user2)
+        activate(user3)
+
         # Post as user 1 and ensure user 1 exists in Redis
         post1 = create_post(user1, 'user1', 'Test post 1')
         self.assertIsNotNone(r.zrank(K.POST_SUBSCRIBERS.format(post1), user1))
@@ -572,6 +576,10 @@ class PostBackendTests(BackendTestCase):
         user2 = create_account('user2', 'user2@pjuu.com', 'Password')
         user3 = create_account('user3', 'user3@pjuu.com', 'Password')
         # No need to activate the accounts
+
+        activate(user1)
+        activate(user2)
+        activate(user3)
 
         # User1 tag user2 in a post
         post1 = create_post(user1, 'user1', 'Hello @user2')

--- a/tests/test_users_frontend.py
+++ b/tests/test_users_frontend.py
@@ -274,7 +274,7 @@ class FrontendTests(FrontendTestCase):
 
         # Lets check to see if inactive users show up. THEY SHOULD
         resp = self.client.get(url_for('users.search', query='fil'))
-        self.assertIn('<!-- list:user:%s -->' % user5, resp.data)
+        self.assertNotIn('<!-- list:user:%s -->' % user5, resp.data)
 
         # Lets check that we can find ant because we are going to delete him
         # to ensure he goes! This has caused issues on the live site


### PR DESCRIPTION
This was a little tougher than first thought as it needed changing at
the auth app level. Have had to add a flag to allow non-active users to
still show for things such as password reset.

Also show activation status in the dashboard and increased the user list
to 10 users from 5.

As a side. When working on JS stuff earlier I left in a 5 second timeout
on new alerts checks. This has increased load on `pjuu.com` and has now
been returned to 30s.

Closes #191