### PR TITLE
Allow new lines in posts.

### DIFF
--- a/pjuu/posts/views.py
+++ b/pjuu/posts/views.py
@@ -29,7 +29,7 @@ posts_bp = Blueprint('posts', __name__)
 
 
 @posts_bp.app_template_filter('postify')
-def postify_filter(post):
+def postify_filter(post, limit_lines=False):
     """Will highlight everything that is stored along with the post: link,
     mentions and hash tags.
 
@@ -84,6 +84,12 @@ def postify_filter(post):
 
         offset += len(html) - (item['span'][1] - item['span'][0])
         post_body = post_body[:left] + html + post_body[right:]
+
+    if limit_lines:
+        post_body = '\n'.join(post_body.splitlines()[:5])
+
+    # Enable new lines to show
+    post_body = post_body.replace("\n", "<br/>")
 
     return post_body
 

--- a/pjuu/settings.py
+++ b/pjuu/settings.py
@@ -68,6 +68,9 @@ ALERT_ITEMS_PER_PAGE = 50
 # Max search items is needed to work pagination across search terms
 MAX_SEARCH_ITEMS = 500
 
+# Line cap (the number of lines to show in a feed before 'Read more...' shows)
+LINE_CAP = 5
+
 # OpBeat config
 OPBEAT_ORG_ID = ''
 OPBEAT_APP_ID = ''

--- a/pjuu/templates/list_post.html
+++ b/pjuu/templates/list_post.html
@@ -33,9 +33,22 @@
             <span class="created">{{ item.created|timeify }}</span>
         </div>
         <div class="body">
+            {% set line_count = item.body.count('\n') %}
             {% autoescape false %}
-            {{ item|postify }}
+                {% if line_count > config.LINE_CAP %}
+                    {{ item|postify(limit_lines=True) }}
+                {% else %}
+                    {{ item|postify }}
+                {% endif %}
             {% endautoescape %}
+
+            {% if line_count > config.LINE_CAP %}
+            <p>
+                <a href="{{ url_for('posts.view_post', username=item.username, post_id=item._id) }}">
+                    Read more ...
+                </a>
+            </p>
+            {% endif %}
         </div>
         {% if item.upload %}
             {% if config.TESTING %}

--- a/pjuu/templates/list_reply.html
+++ b/pjuu/templates/list_reply.html
@@ -26,7 +26,7 @@
         </div>
         <div class="body">
             {% autoescape false %}
-            {{ item|postify }}
+                {{ item|postify }}
             {% endautoescape %}
         </div>
         {% if item.upload %}


### PR DESCRIPTION
Posts can now include new lines. They will be limited to 5 lines on
users profiles and feeds.

Closes #112.