### PR TITLE
Allow users to reverse/re-vote within a timeframe.

### DIFF
--- a/pjuu/lib/keys.py
+++ b/pjuu/lib/keys.py
@@ -17,6 +17,10 @@ EXPIRE_MILLISECONDS = EXPIRE_SECONDS * 1000
 EXPIRE_24HRS = 24 * 60 * 60
 EXPIRE_4WKS = 28 * 24 * 60 * 60
 
+# Vote expiration timeout
+# You can remove your vote within this time (5mins)
+VOTE_TIMEOUT = 300
+
 # Standard contants
 # We occasionally need to set a key to something which is invalid and which
 # we can test for. For example when a user is deleted there username is

--- a/pjuu/templates/list_post.html
+++ b/pjuu/templates/list_post.html
@@ -87,39 +87,41 @@
                 {% if item.user_id != current_user._id %}
                 {% set voted_on = item._id|voted %}
                 <li>
-                    {% if voted_on > 0 %}
-                    {% if config.TESTING %}
-                    <!-- upvoted:post:{{ item._id }} -->
-                    {% endif %}
-                    <i class="fa fa-arrow-up fa-lg upvoted"></i>
-                    {% elif voted_on < 0 %}
-                    <i class="fa fa-arrow-up fa-lg inactive"></i>
+                    {% if voted_on > 0 and not voted_on|reversable %}
+                        <i class="fa fa-arrow-up fa-lg upvoted"></i>
+                    {% elif voted_on < 0 and not voted_on|reversable %}
+                        <i class="fa fa-arrow-up fa-lg inactive"></i>
                     {% else %}
-                    {% if config.TESTING %}
-                    <!-- upvote:post:{{ item._id }} -->
-                    {% endif %}
-                    <form action="{{ url_for('posts.upvote', username=item.username, post_id=item._id, next=request.path + '?' + request.query_string) }}" method="post">
-                        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-                        <button title="Up vote" class="fa fa-arrow-up fa-lg link upvote buttonlink"></button>
-                    </form>
+                        {% if config.TESTING %}
+                            {% if voted_on > 0 %}
+                            <!-- upvoted:post:{{ item._id }} -->
+                            {% else %}
+                            <!-- upvote:post:{{ item._id }} -->
+                            {% endif %}
+                        {% endif %}
+                        <form action="{{ url_for('posts.upvote', username=item.username, post_id=item._id, next=request.path + '?' + request.query_string) }}" method="post">
+                            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                            <button title="Up vote" class="fa fa-arrow-up fa-lg link {% if voted_on > 0 %}upvoted{% else %}upvote{% endif %}  buttonlink"></button>
+                        </form>
                     {% endif %}
                 </li>
                 <li>
-                    {% if voted_on < 0 %}
-                    {% if config.TESTING %}
-                    <!-- downvoted:post:{{ item._id }} -->
-                    {% endif %}
-                    <i class="fa fa-arrow-down fa-lg downvoted"></i>
-                    {% elif voted_on > 0 %}
-                    <i class="fa fa-arrow-down fa-lg inactive"></i>
+                    {% if voted_on < 0 and not voted_on|reversable %}
+                        <i class="fa fa-arrow-up fa-lg downvoted"></i>
+                    {% elif voted_on > 0 and not voted_on|reversable %}
+                        <i class="fa fa-arrow-down fa-lg inactive"></i>
                     {% else %}
-                    {% if config.TESTING %}
-                    <!-- downvote:post:{{ item._id }} -->
-                    {% endif %}
-                    <form action="{{ url_for('posts.downvote', username=item.username, post_id=item._id, next=request.path + '?' + request.query_string) }}" method="post">
-                        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-                        <button title="Down vote" class="fa fa-arrow-down fa-lg link downvote buttonlink"></button>
-                    </form>
+                        {% if config.TESTING %}
+                            {% if voted_on < 0 %}
+                            <!-- downvoted:post:{{ item._id }} -->
+                            {% else %}
+                            <!-- downvote:post:{{ item._id }} -->
+                            {% endif %}
+                        {% endif %}
+                        <form action="{{ url_for('posts.downvote', username=item.username, post_id=item._id, next=request.path + '?' + request.query_string) }}" method="post">
+                            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                            <button title="Down vote" class="fa fa-arrow-down fa-lg link {% if voted_on < 0 %}downvoted{% else %}downvote{% endif %} buttonlink"></button>
+                        </form>
                     {% endif %}
                 </li>
                 {% endif %}

--- a/pjuu/templates/list_reply.html
+++ b/pjuu/templates/list_reply.html
@@ -48,39 +48,41 @@
                 {% if item.user_id != current_user._id %}
                 {% set voted_on = item._id|voted %}
                 <li>
-                    {% if voted_on > 0 %}
-                    {% if config.TESTING %}
-                    <!-- upvoted:reply:{{ item._id }} -->
-                    {% endif %}
-                    <i class="fa fa-arrow-up fa-lg upvoted"></i>
-                    {% elif voted_on < 0 %}
-                    <i class="fa fa-arrow-up fa-lg inactive"></i>
+                    {% if voted_on > 0 and not voted_on|reversable %}
+                        <i class="fa fa-arrow-up fa-lg upvoted"></i>
+                    {% elif voted_on < 0 and not voted_on|reversable %}
+                        <i class="fa fa-arrow-up fa-lg inactive"></i>
                     {% else %}
-                    {% if config.TESTING %}
-                    <!-- upvote:reply:{{ item._id }} -->
-                    {% endif %}
-                    <form action="{{ url_for('posts.upvote', username=post.username, post_id=item.reply_to, reply_id=item._id, next=request.path + '?' + request.query_string) }}" method="post">
-                        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-                        <button title="Up vote" class="fa fa-arrow-up fa-lg link upvote buttonlink"></button>
-                    </form>
+                        {% if config.TESTING %}
+                            {% if voted_on > 0 %}
+                            <!-- upvoted:reply:{{ item._id }} -->
+                            {% else %}
+                            <!-- upvote:reply:{{ item._id }} -->
+                            {% endif %}
+                        {% endif %}
+                        <form action="{{ url_for('posts.upvote', username=post.username, post_id=item.reply_to, reply_id=item._id, next=request.path + '?' + request.query_string) }}" method="post">
+                            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                            <button title="Up vote" class="fa fa-arrow-up fa-lg link {% if voted_on > 0 %}upvoted{% else %}upvote{% endif %}  buttonlink"></button>
+                        </form>
                     {% endif %}
                 </li>
                 <li>
-                    {% if voted_on < 0 %}
-                    {% if config.TESTING %}
-                    <!-- downvoted:reply:{{ item._id }} -->
-                    {% endif %}
-                    <i class="fa fa-arrow-down fa-lg downvoted"></i>
-                    {% elif voted_on > 0 %}
-                    <i class="fa fa-arrow-down fa-lg inactive"></i>
+                    {% if voted_on < 0 and not voted_on|reversable %}
+                        <i class="fa fa-arrow-up fa-lg downvoted"></i>
+                    {% elif voted_on > 0 and not voted_on|reversable %}
+                        <i class="fa fa-arrow-down fa-lg inactive"></i>
                     {% else %}
-                    {% if config.TESTING %}
-                    <!-- downvote:reply:{{ item._id }} -->
-                    {% endif %}
-                    <form action="{{ url_for('posts.downvote', username=post.username, post_id=item.reply_to, reply_id=item._id, next=request.path + '?' + request.query_string) }}" method="post">
-                        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-                        <button title="Down vote" class="fa fa-arrow-down fa-lg link downvote buttonlink"></button>
-                    </form>
+                        {% if config.TESTING %}
+                            {% if voted_on < 0 %}
+                            <!-- downvoted:reply:{{ item._id }} -->
+                            {% else %}
+                            <!-- downvote:reply:{{ item._id }} -->
+                            {% endif %}
+                        {% endif %}
+                        <form action="{{ url_for('posts.downvote', username=post.username, post_id=item.reply_to, reply_id=item._id, next=request.path + '?' + request.query_string) }}" method="post">
+                            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                            <button title="Down vote" class="fa fa-arrow-down fa-lg link {% if voted_on < 0 %}downvoted{% else %}downvote{% endif %} buttonlink"></button>
+                        </form>
                     {% endif %}
                 </li>
                 {% endif %}

--- a/pjuu/templates/view_post.html
+++ b/pjuu/templates/view_post.html
@@ -62,39 +62,41 @@
                 {% if post.user_id != current_user._id %}
                 {% set voted_on = post._id|voted %}
                 <li>
-                    {% if voted_on > 0 %}
-                    {% if config.TESTING %}
-                    <!-- upvoted:post:{{ post._id }} -->
-                    {% endif %}
-                    <i class="fa fa-arrow-up fa-lg upvoted"></i>
-                    {% elif voted_on < 0 %}
-                    <i class="fa fa-arrow-up fa-lg inactive"></i>
+                    {% if voted_on > 0 and not voted_on|reversable %}
+                        <i class="fa fa-arrow-up fa-lg upvoted"></i>
+                    {% elif voted_on < 0 and not voted_on|reversable %}
+                        <i class="fa fa-arrow-up fa-lg inactive"></i>
                     {% else %}
-                    {% if config.TESTING %}
-                    <!-- upvote:post:{{ post._id }} -->
-                    {% endif %}
-                    <form action="{{ url_for('posts.upvote', username=post.username, post_id=post._id, next=request.path) }}" method="post">
-                        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-                        <button title="Up vote" class="fa fa-arrow-up fa-lg link upvote"></button>
-                    </form>
+                        {% if config.TESTING %}
+                            {% if voted_on > 0 %}
+                            <!-- upvoted:post:{{ post._id }} -->
+                            {% else %}
+                            <!-- upvote:post:{{ post._id }} -->
+                            {% endif %}
+                        {% endif %}
+                        <form action="{{ url_for('posts.upvote', username=post.username, post_id=post._id, next=request.path + '?' + request.query_string) }}" method="post">
+                            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                            <button title="Up vote" class="fa fa-arrow-up fa-lg link {% if voted_on > 0 %}upvoted{% else %}upvote{% endif %}  buttonlink"></button>
+                        </form>
                     {% endif %}
                 </li>
                 <li>
-                    {% if voted_on < 0 %}
-                    {% if config.TESTING %}
-                    <!-- downvoted:post:{{ post._id }} -->
-                    {% endif %}
-                    <i class="fa fa-arrow-down fa-lg downvoted"></i>
-                    {% elif voted_on > 0 %}
-                    <i class="fa fa-arrow-down fa-lg inactive"></i>
+                    {% if voted_on < 0 and not voted_on|reversable %}
+                        <i class="fa fa-arrow-up fa-lg downvoted"></i>
+                    {% elif voted_on > 0 and not voted_on|reversable %}
+                        <i class="fa fa-arrow-down fa-lg inactive"></i>
                     {% else %}
-                    {% if config.TESTING %}
-                    <!-- downvote:post:{{ post._id }} -->
-                    {% endif %}
-                    <form action="{{ url_for('posts.downvote', username=post.username, post_id=post._id, next=request.path) }}" method="post">
-                        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-                        <button title="Down vote" class="fa fa-arrow-down fa-lg link downvote"></button>
-                    </form>
+                        {% if config.TESTING %}
+                            {% if voted_on < 0 %}
+                            <!-- downvoted:post:{{ post._id }} -->
+                            {% else %}
+                            <!-- downvote:post:{{ post._id }} -->
+                            {% endif %}
+                        {% endif %}
+                        <form action="{{ url_for('posts.downvote', username=post.username, post_id=post._id, next=request.path + '?' + request.query_string) }}" method="post">
+                            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+                            <button title="Down vote" class="fa fa-arrow-down fa-lg link {% if voted_on < 0 %}downvoted{% else %}downvote{% endif %} buttonlink"></button>
+                        </form>
                     {% endif %}
                 </li>
                 {% endif %}


### PR DESCRIPTION
Users can now reverse their votes within the VOTE_TIMEOUT seconds.
This will count as them not voting at all and can vote again within any
time period.

Users can also change their vote. So an upvote can become a downvote
effectivley reset the vote timeout.

Users can also go in to negative scores. This was the only way to
implement this without an extra score applied counter.