### PR TITLE
Fixed issue with incorrect arrow on downvoted.

### DIFF
--- a/pjuu/templates/list_post.html
+++ b/pjuu/templates/list_post.html
@@ -107,7 +107,7 @@
                 </li>
                 <li>
                     {% if voted_on < 0 and not voted_on|reversable %}
-                        <i class="fa fa-arrow-up fa-lg downvoted"></i>
+                        <i class="fa fa-arrow-down fa-lg downvoted"></i>
                     {% elif voted_on > 0 and not voted_on|reversable %}
                         <i class="fa fa-arrow-down fa-lg inactive"></i>
                     {% else %}

--- a/pjuu/templates/list_reply.html
+++ b/pjuu/templates/list_reply.html
@@ -68,7 +68,7 @@
                 </li>
                 <li>
                     {% if voted_on < 0 and not voted_on|reversable %}
-                        <i class="fa fa-arrow-up fa-lg downvoted"></i>
+                        <i class="fa fa-arrow-down fa-lg downvoted"></i>
                     {% elif voted_on > 0 and not voted_on|reversable %}
                         <i class="fa fa-arrow-down fa-lg inactive"></i>
                     {% else %}

--- a/pjuu/templates/view_post.html
+++ b/pjuu/templates/view_post.html
@@ -82,7 +82,7 @@
                 </li>
                 <li>
                     {% if voted_on < 0 and not voted_on|reversable %}
-                        <i class="fa fa-arrow-up fa-lg downvoted"></i>
+                        <i class="fa fa-arrow-down fa-lg downvoted"></i>
                     {% elif voted_on > 0 and not voted_on|reversable %}
                         <i class="fa fa-arrow-down fa-lg inactive"></i>
                     {% else %}


### PR DESCRIPTION
Didn't notice this in development. If a post is downvoted and can't be
reversed (after VOTE_TIMEOUT) it would have the correct colors but an up
arrow.