### PR TITLE
Changed "approved" to "trusted" to save confusion.

### DIFF
--- a/pjuu/static/css/style.css
+++ b/pjuu/static/css/style.css
@@ -371,14 +371,14 @@ button:hover {
     background-color: #FFEA39;
     border: 1px solid #FFEA39;
     color: #000;
-    content: "Approved";
+    content: "Trusted";
 }
 
 .unapprove:hover {
     background-color: #C00;
     border: 1px solid #C00;
     color: #FFF;
-    content: "Un-approve";
+    content: "Untrust";
 }
 
 .username a {
@@ -1053,41 +1053,37 @@ input[type="file"] {
     list-style: none;
 }
 
-#setting #permission label {
+#setting #permission li {
+    margin-top: 1em;
+}
+
+#setting #permission li label {
     cursor: pointer;
     display: block;
     padding: 0.25em 0.5em;
 }
 
-#setting #permission input[type=radio]:checked + i {
-    color: #0C0;
-}
-
-#setting #permission li:first-child {
-    border-radius: 3px 0 0 3px;
-    border-right: 0;
-}
-
-#setting #permission li:last-child {
-    border-radius: 0 3px 3px 0;
-    border-right: 1px solid #666;
-}
-
-#setting #permission li {
+#setting #permission li label {
+    float: left;
     border: 1px solid #666;
-    border-right: 0;
+    border-radius: 3px;
     color: #666;
     background-color: #FFF;
-    float: left;
+    margin-right: 1em;
 }
 
-#setting #permission li:hover {
-    color: #333;
+#setting #permission li div {
+    padding: 0;
+    margin-left: 4em;
 }
 
 #setting #permission input[type=radio] {
     position: absolute;
     left: -9999px;
+}
+
+#setting #permission input[type=radio]:checked + i {
+    color: #0C0;
 }
 
 /* DASHBOARD =============================================================== */

--- a/pjuu/static/js/pjuu.js
+++ b/pjuu/static/js/pjuu.js
@@ -23,6 +23,7 @@ $(document).ready(function() {
     /*
      * Remove image upload field if it is set in the JS. Mainly for Android.
      * If there is a function defined within the Android app this will not show.
+     * This feature does not work in Kitkat!
      */
     try {
         $('#upload-label').toggle(!Android.hideImageUpload());
@@ -31,7 +32,7 @@ $(document).ready(function() {
     }
 
     /*
-     * Allow Ctrl+Enter to submit the auth form
+     * Allow Ctrl+Enter to submit the post form
      */
     $('#author #body').keydown(function (event) {
         if (event.ctrlKey && (event.keyCode == 10 || event.keyCode == 13)) {
@@ -110,6 +111,18 @@ $(document).ready(function() {
         },
         function() {
             $(this).html("You");
+        }
+    );
+
+    /*
+     * Change the trusted button on mouse actions.
+     */
+    $(".action.unapprove").hover (
+        function() {
+            $(this).html("Untrust")
+        },
+        function() {
+            $(this).html("Trusted");
         }
     );
 

--- a/pjuu/templates/author_post.html
+++ b/pjuu/templates/author_post.html
@@ -20,14 +20,14 @@
                     <label>
                         <input name="permission"
                             {% if permission == 1 %}checked="true"{% endif %} value="1" type="radio" />
-                        <i title="Pjuu" class="fa fa-fw fa-circle-o"></i>
+                        <i title="Pjuu users only" class="fa fa-fw fa-circle-o"></i>
                     </label>
                 </li>
                 <li>
                     <label>
                         <input name="permission"
                             {% if permission == 2 %}checked="true"{% endif %} value="2" type="radio" />
-                        <i title="Approved" class="fa fa-fw fa-check"></i>
+                        <i title="Trusted users only" class="fa fa-fw fa-check"></i>
                     </label>
                 </li>
             </ul>

--- a/pjuu/templates/list_user.html
+++ b/pjuu/templates/list_user.html
@@ -28,12 +28,12 @@
             {% if item|approved %}
             <form action="{{ url_for('users.unapprove', username=item.username, next=request.path + '?' + request.query_string) }}" method="post">
                 <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-                <button class="action unapprove">Approved</button>
+                <button class="action unapprove">Trusted</button>
             </form>
             {% else %}
             <form action="{{ url_for('users.approve', username=item.username, next=request.path + '?' + request.query_string) }}" method="post">
                 <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-                <button class="action approve">Approve</button>
+                <button class="action approve">Trust</button>
             </form>
             {% endif %}
         {% endif %}

--- a/pjuu/templates/settings_profile.html
+++ b/pjuu/templates/settings_profile.html
@@ -51,6 +51,26 @@
                 </div>
             </div>
         </div>
+
+        <div class="details clearfix">
+            <div class="detail">
+                <div class="header">{{ form.about.label }}</div>
+                <div class="content">
+                    <textarea id="about" name="about" rows="5" maxlength="{{ form.about.validators[0].max }}" placeholder="Set your about me...">{{ current_user.about }}</textarea>
+                    <div id="count">
+                        {{ current_user.about|length }} / {{ form.about.validators[0].max }}
+                    </div>
+                    {% if form.about.errors %}
+                    <ul class="errorlist">
+                        {% for error in form.about.errors %}
+                        <li>{{ error }}</li>
+                        {% endfor %}
+                    </ul>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+
         <div class="details">
             <div class="detail">
                 <div class="header">Additional information</div>
@@ -72,6 +92,7 @@
                     </div>
                 </div>
             </div>
+
             <div class="detail">
                 <div class="header">
                     Display settings
@@ -100,11 +121,10 @@
 
             <div class="detail clearfix">
                 <div class="header">
-                    Post settings
+                    Default post permission
                 </div>
                 <div class="content">
                     <div>
-                        Default post permission:
                         <ul id="permission">
                             <li>
                                 <label>
@@ -112,6 +132,9 @@
                                         {% if current_user.default_permission == 0 %}checked="true"{% endif %} value="0" type="radio" />
                                     <i title="Public" class="fa fa-fw fa-globe"></i>
                                 </label>
+                                <div>
+                                Allow all users including non-pjuu users to view the post and see it on your profile.
+                                </div>
                             </li>
                             <li>
                                 <label>
@@ -119,6 +142,9 @@
                                         {% if current_user.default_permission == 1 %}checked="true"{% endif %} value="1" type="radio" />
                                     <i title="Pjuu" class="fa fa-fw fa-circle-o"></i>
                                 </label>
+                                <div>
+                                Only allow Pjuu users to view the post and see it on your profile.
+                                </div>
                             </li>
                             <li>
                                 <label>
@@ -126,27 +152,12 @@
                                         {% if current_user.default_permission == 2 %}checked="true"{% endif %} value="2" type="radio" />
                                     <i title="Approved" class="fa fa-fw fa-check"></i>
                                 </label>
+                                <div>
+                                Only allow users you have marked as trusted followers to view the post and see it on your profile.
+                                </div>
                             </li>
                         </ul>
                     </div>
-                </div>
-            </div>
-        </div>
-        <div class="details">
-            <div class="detail">
-                <div class="header">{{ form.about.label }}</div>
-                <div class="content">
-                    <textarea id="about" name="about" rows="5" maxlength="{{ form.about.validators[0].max }}" placeholder="Set your about me...">{{ current_user.about }}</textarea>
-                    <div id="count">
-                        {{ current_user.about|length }} / {{ form.about.validators[0].max }}
-                    </div>
-                    {% if form.about.errors %}
-                    <ul class="errorlist">
-                        {% for error in form.about.errors %}
-                        <li>{{ error }}</li>
-                        {% endfor %}
-                    </ul>
-                    {% endif %}
                 </div>
             </div>
         </div>

--- a/pjuu/users/views.py
+++ b/pjuu/users/views.py
@@ -307,12 +307,12 @@ def approve(username):
 
     if user_id != current_user.get('_id'):
         if approve_user(current_user.get('_id'), user_id):
-            flash('You have approved %s' % username, 'success')
+            flash('You have put your trust %s' % username, 'success')
         else:
-            flash('You can\'t approve a user who is not following you',
-                  'information')
+            flash('You can\'t trust a user who is not following you',
+                  'error')
     else:
-        flash('You can\'t approve your self', 'information')
+        flash('You should already trust yourself ;-P', 'information')
 
     return redirect(redirect_url)
 
@@ -332,12 +332,12 @@ def unapprove(username):
 
     if user_id != current_user.get('_id'):
         if unapprove_user(current_user.get('_id'), user_id):
-            flash('You have un-approved %s' % username, 'success')
+            flash('You have untrusted %s' % username, 'success')
         else:
-            flash('You can\'t unapprove a user which is not approved',
-                  'information')
+            flash('You can\'t untrust a user who is not trusted',
+                  'error')
     else:
-        flash('You can\'t unapprove your self', 'information')
+        flash('You can\'t untrust your self', 'information')
 
     return redirect(redirect_url)
 

--- a/tests/test_users_frontend.py
+++ b/tests/test_users_frontend.py
@@ -261,14 +261,14 @@ class FrontendTests(FrontendTestCase):
         resp = self.client.post(url_for('users.unapprove', username='user2'),
                                 follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn('You can\'t unapprove a user which is not approved',
+        self.assertIn('You can\'t untrust a user who is not trusted',
                       resp.data)
 
         # Try and approve a user who is not following you
         resp = self.client.post(url_for('users.approve', username='user3'),
                                 follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn('You can\'t approve a user who is not following you',
+        self.assertIn('You can\'t trust a user who is not following you',
                       resp.data)
 
         # Try again but you are following the user (wont-work)
@@ -276,20 +276,20 @@ class FrontendTests(FrontendTestCase):
         resp = self.client.post(url_for('users.approve', username='user3'),
                                 follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn('You can\'t approve a user who is not following you',
+        self.assertIn('You can\'t trust a user who is not following you',
                       resp.data)
 
         # Try and approve yourself
         resp = self.client.post(url_for('users.approve', username='user1'),
                                 follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn('You can\'t approve your self', resp.data)
+        self.assertIn('You should already trust yourself ;-P', resp.data)
 
         # Try and unapprove self
         resp = self.client.post(url_for('users.unapprove', username='user1'),
                                 follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn('You can\'t unapprove your self', resp.data)
+        self.assertIn('You can\'t untrust your self', resp.data)
 
         # Try and approve/unapprove a user that doesn't exist
         resp = self.client.post(url_for('users.approve', username='user5'),


### PR DESCRIPTION
Approved users are now called "trusted" users every where on the site.
Changed the settings page to better describe each post permission.
Cleaned up some JS stuffs and added in change to trust buttons.

Closes #240 