### PR TITLE
Typo: s/you/your/

### DIFF
--- a/pjuu/templates/settings_profile.html
+++ b/pjuu/templates/settings_profile.html
@@ -178,7 +178,7 @@
                     {% endif %}
                 {% endif %}
                 <div>
-                    Reset all tip's on the site as if you had never seen them.
+                    Reset all tips on the site as if you had never seen them.
                 </div>
             </div>
         </div>

--- a/pjuu/templates/settings_profile.html
+++ b/pjuu/templates/settings_profile.html
@@ -45,7 +45,7 @@
                         </label>
                     </div>
                     <div>
-                        <p>We will ensure the image is <b>96px by 96px</b>. For best results please ensure you avatar file is that size.</p>
+                        <p>We will ensure the image is <b>96px by 96px</b>. For best results please ensure your avatar file is that size.</p>
                         <p><i>This will not take effect until you "Update Profile" at the bottom.</i></p>
                     </div>
                 </div>


### PR DESCRIPTION
I just corrected some typo in the settings page. "your avatar file", not "you avatar file", and "tips" plural, not "tip's" possessive.

(I didn't know whether it was better to suggest such small changes as an issue or just fix it, so I did the latter.)