### PR TITLE
Fixed issue with New Lines being 2 characters.

### DIFF
--- a/pjuu/posts/forms.py
+++ b/pjuu/posts/forms.py
@@ -10,8 +10,8 @@
 # 3rd party imports
 from flask_wtf import Form
 from flask_wtf.file import FileAllowed, FileField
-from wtforms import TextAreaField, RadioField
-from wtforms.validators import DataRequired, Length
+from wtforms import TextAreaField, RadioField, ValidationError
+from wtforms.validators import DataRequired
 # Pjuu imports
 from pjuu.posts.backend import MAX_POST_LENGTH
 
@@ -20,13 +20,10 @@ class PostForm(Form):
     """Handle the input from the web for posts and replies.
 
     """
+    MAX_POST_LENGTH = MAX_POST_LENGTH
 
     body = TextAreaField('Post', [
         DataRequired('A message is required.'),
-        Length(max=MAX_POST_LENGTH,
-               message='Posts can not be larger than '
-                       '{} characters'.format(MAX_POST_LENGTH))
-
     ])
 
     upload = FileField('Upload', [
@@ -39,3 +36,8 @@ class PostForm(Form):
         ('1', 'Pjuu'),
         ('2', 'Approved')
     ], default=0)
+
+    def validate_body(self, field):
+        if len(field.data.replace('\r\n', '\n')) > MAX_POST_LENGTH:
+            raise ValidationError('Posts can not be larger than '
+                                  '{} characters'.format(MAX_POST_LENGTH))

--- a/pjuu/templates/author_post.html
+++ b/pjuu/templates/author_post.html
@@ -3,9 +3,9 @@
 {% endif %}
 <div id="author" class="block post clearfix">
     <form action="{{ url_for('posts.post', next=request.path) }}" method="post" enctype="multipart/form-data">
-        {{ post_form.body(rows=2, maxlength=post_form.body.validators[1].max, placeholder="Write a post...") }}
+        {{ post_form.body(rows=2, maxlength=post_form.MAX_POST_LENGTH, placeholder="Write a post...") }}
         {{ post_form.csrf_token }}
-        <div id="count">0 / {{ post_form.body.validators[1].max }}</div>
+        <div id="count">0 / {{ post_form.MAX_POST_LENGTH }}</div>
         <div id="action">
             {% set permission = current_user.get('default_permission', 0) %}
             <ul id="permission">

--- a/pjuu/templates/author_reply.html
+++ b/pjuu/templates/author_reply.html
@@ -3,9 +3,9 @@
 {% endif %}
 <div id="author" class="block comment clearfix">
     <form action="{{ url_for('posts.post', username=post.username, post_id=post._id, next=request.path) }}" method="post" enctype="multipart/form-data">
-        {{ post_form.body(rows=2, maxlength=post_form.body.validators[1].max, placeholder="Leave a comment...") }}
+        {{ post_form.body(rows=2, maxlength=post_form.MAX_POST_LENGTH, placeholder="Leave a comment...") }}
         {{ post_form.csrf_token }}
-        <div id="count">0 / {{ post_form.body.validators[1].max }}</div>
+        <div id="count">0 / {{ post_form.MAX_POST_LENGTH }}</div>
         <div id="action">
             <label id="upload-label" for="upload" style="display: none;">
                 {{ post_form.upload(accept='image/*') }}


### PR DESCRIPTION
JS classed them as one. May be confusing if it didn't.
Make Python count them as one by overwriting validator.