### PR TITLE
TESTING is now not used in development.

### DIFF
--- a/pjuu/__init__.py
+++ b/pjuu/__init__.py
@@ -133,9 +133,10 @@ def create_app(config_filename='settings.py', config_dict=None):
                 values[param_name] = int(os.stat(
                     os.path.join(static_folder, filename)).st_mtime)
 
-    # Register error handlers
-    from pjuu.lib.errors import register_errors
-    register_errors(app)
+    if not app.debug or (app.debug and app.testing):  # pragma: no branch
+        # Register error handlers
+        from pjuu.lib.errors import register_errors
+        register_errors(app)
 
     # Import all Pjuu blue prints
     from pjuu.auth.views import auth_bp

--- a/pjuu/auth/views.py
+++ b/pjuu/auth/views.py
@@ -70,7 +70,7 @@ def inject_token_header(response):
     Will only ever do this if testing mode is on!
 
     """
-    if app.testing:  # pragma: no branch
+    if app.debug or app.testing:  # pragma: no branch
         token = g.get('token')
         if token:
             response.headers['X-Pjuu-Token'] = token

--- a/pjuu/lib/tokens.py
+++ b/pjuu/lib/tokens.py
@@ -35,7 +35,7 @@ def generate_token(data):
     # For testing if a token is generated add it as a HTTP Header for us to
     # check with the test client.
     # Only ever do this in testing mode
-    if app.testing:  # pragma: no branch
+    if app.debug or app.testing:  # pragma: no branch
         g.token = tid
 
     return tid

--- a/pjuu/settings.py
+++ b/pjuu/settings.py
@@ -16,7 +16,7 @@ DEBUG = True
 # you can find them in Headers as X-Pjuu-Token on the return from a function.
 # Note: It will be attached to the 302 is most cases so ensure you check the
 # correct response to find this
-TESTING = True
+TESTING = False
 
 # In the case of testing we need a server name, so here's one:
 # SERVER_NAME = 'localhost'
@@ -46,6 +46,7 @@ SESSION_COOKIE_HTTPONLY = True
 SESSION_COOKIE_SECURE = False
 
 # Flask-Mail
+MAIL_SUPPRESS_SEND = DEBUG
 MAIL_SERVER = 'localhost'
 MAIL_PORT = 25
 MAIL_USE_TLS = False


### PR DESCRIPTION
- Endpoint timings to appear in the console of dev mode.
- Werkzeug error messages will be shown in dev mode but not if TESTING
  is on. If neither is on custom error messages will be shown.
- TESTING is not on by default.
- In DEVELOPMENT e-mails will not be sent.