### PR TITLE
Initial Alpine images 

### DIFF
--- a/pjuu-base.Dockerfile
+++ b/pjuu-base.Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine:latest
+LABEL maintainer ant@pjuu.com
+
+RUN apk add --no-cache --virtual .builddeps build-base python-dev wget curl git && \
+    apk add --no-cache python py-virtualenv imagemagick
+
+RUN mkdir -p /data/conf /data/pjuu
+
+WORKDIR /data
+
+# add stuff to image requirements, entrypoint and pjuu src
+ADD ./requirements-base.txt /data/requirements-base.txt
+ADD ./pjuu /data/pjuu
+
+RUN virtualenv /data/venv
+RUN /data/venv/bin/pip install -r /data/requirements-base.txt
+

--- a/pjuu-base.Dockerfile
+++ b/pjuu-base.Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 LABEL maintainer ant@pjuu.com
 
-RUN apk add --no-cache --virtual .builddeps build-base python-dev wget curl git && \
+RUN apk add --no-cache --virtual .build-deps build-base python-dev wget curl git && \
     apk add --no-cache python py-virtualenv imagemagick
 
 RUN mkdir -p /data/conf /data/pjuu
@@ -14,4 +14,6 @@ ADD ./pjuu /data/pjuu
 
 RUN virtualenv /data/venv
 RUN /data/venv/bin/pip install -r /data/requirements-base.txt
+
+RUN apk del .build-deps
 

--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -1,28 +1,5 @@
-FROM debian:jessie
-MAINTAINER Joe Doherty <joe@pjuu.com>
-
-# Install all system requirements
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && \
-    apt-get -y -qq install openssl ca-certificates build-essential python-dev python-setuptools \
-    libmagickwand-dev && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-RUN easy_install virtualenv
-RUN mkdir -p /data/conf /data/pjuu
-
-WORKDIR /data
-
-# PIP stuff
-COPY ./requirements-base.txt /data/requirements-base.txt
-
-RUN virtualenv /data/venv
-RUN /data/venv/bin/pip install -r /data/requirements-base.txt
-
-# Copy the Pjuu source code, "pjuu/" in the current directory
-COPY ./pjuu /data/pjuu
-
-# Pjuu needs config from the host!
-VOLUME ["/data/conf"]
+FROM pjuu:base
+LABEL maintainer Joe Doherty <joe@pjuu.com>
 
 # Gunicorn available to the Docker container
 EXPOSE 8000

--- a/worker-entrypoint.sh
+++ b/worker-entrypoint.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 PJUU_SETTINGS=/data/conf/pjuu.conf /data/venv/bin/celery worker -A pjuu.celery_app

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -1,30 +1,10 @@
-FROM debian:jessie
-MAINTAINER Joe Doherty <joe@pjuu.com>
-
-# Install all system requirements
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && \
-    apt-get -y -qq install openssl ca-certificates build-essential python-dev python-setuptools \
-    libmagickwand-dev && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-RUN easy_install virtualenv
-RUN mkdir -p /data/conf /data/pjuu
+FROM pjuu:base
+LABEL maintainer ant@pjuu.com
 
 WORKDIR /data
 
-# PIP stuff
-COPY ./requirements-base.txt /data/requirements-base.txt
-
-RUN virtualenv /data/venv
-RUN /data/venv/bin/pip install -r /data/requirements-base.txt
-
-# Copy the Pjuu source code, "pjuu/" in the current directory
-COPY ./pjuu /data/pjuu
-
-# Pjuu needs config from the host!
-VOLUME ["/data/conf"]
-
 ADD ./worker-entrypoint.sh /data/worker-entrypoint.sh
+
 RUN chmod +x worker-entrypoint.sh
 
 # Run Celery


### PR DESCRIPTION
Dont merge yet without some testing!

Moves common stuff in to base image rather than having two images that are basically the same

Given web and worker are basically the same they would now pull from pjuu:base then setup for each task.

This when testing gives a saving of ~200 mb on the image itself. Reducing need to have two separate images knocks it down by ~ 800M or so
