### PR TITLE
Correct base build path in web/worker

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -18,4 +18,3 @@ RUN python3 -m venv /data/venv
 RUN /data/venv/bin/pip install -r /data/requirements-base.txt
 
 RUN apk del .build-deps
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@
 version: "3"
 services:
   pjuu:
-    image: pjuu/pjuu:web
+    image: pjuu/web:latest
     deploy:
       restart_policy:
         condition: any
@@ -23,7 +23,7 @@ services:
       - redis
 
   worker:
-    image: pjuu/pjuu:worker
+    image: pjuu/worker:latest
     deploy:
       restart_policy:
         condition: any

--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -1,4 +1,4 @@
-FROM pjuu/pjuu:base
+FROM pjuu/base:latest
 LABEL maintainer Joe Doherty <joe@pjuu.com>
 
 # Gunicorn available to the Docker container

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -1,4 +1,4 @@
-FROM pjuu/pjuu:base
+FROM pjuu/base:latest
 LABEL maintainer ant@pjuu.com
 
 WORKDIR /data


### PR DESCRIPTION
Docker images have been building from an old base image `pjuu/pjuu:base` we've now moved to `pjuu/base:lastest` format.