### PR TITLE
Remove blog link from footer.

### DIFF
--- a/pjuu/templates/footer.html
+++ b/pjuu/templates/footer.html
@@ -5,7 +5,6 @@
         <a href="{{ url_for('pages.privacy') }}">Privacy</a> &middot;
         <a href="{{ url_for('pages.donations') }}">Donations</a> <i class="fa fa-fw fa-heart gold"></i> &middot;
         <a target="_blank" href="https://github.com/pjuu">Github</a> &middot;
-        <a target="_blank" href="http://pjuu.github.io">Blog</a>
         {% if current_user and current_user.op %}
             &nbsp;&middot;
             <a href="{{ url_for('dashboard.dashboard') }}">Dashboard</a>


### PR DESCRIPTION
The blog has been removed. It was never kept up to date. Pjuu itself should hold this data.